### PR TITLE
Update ava to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,70 +5,32 @@
   "requires": true,
   "dependencies": {
     "@ava/babel-plugin-throws-helper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-      "integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-4.0.0.tgz",
+      "integrity": "sha512-3diBLIVBPPh3j4+hb5lo0I1D+S/O/VDJPI4Y502apBxmwEqjyXG4gTSPFUlm41sSZeZzMarT/Gzovw9kV7An0w==",
       "dev": true
     },
     "@ava/babel-preset-stage-4": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
-      "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-4.0.0.tgz",
+      "integrity": "sha512-lZEV1ZANzfzSYBU6WHSErsy7jLPbD1iIgAboASPMcKo7woVni5/5IKWeT0RxC8rY802MFktur3OKEw2JY1Tv2w==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.20.0",
-        "babel-plugin-transform-async-to-generator": "^6.16.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.19.0",
-        "babel-plugin-transform-es2015-function-name": "^6.9.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-        "babel-plugin-transform-es2015-parameters": "^6.21.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.8.0",
-        "package-hash": "^1.2.0"
-      },
-      "dependencies": {
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          }
-        },
-        "package-hash": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
-          "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-          "dev": true,
-          "requires": {
-            "md5-hex": "^1.3.0"
-          }
-        }
+        "@babel/plugin-proposal-async-generator-functions": "7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "7.5.0",
+        "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+        "@babel/plugin-transform-dotall-regex": "7.4.4",
+        "@babel/plugin-transform-modules-commonjs": "7.6.0"
       }
     },
     "@ava/babel-preset-transform-test-files": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
-      "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-6.0.0.tgz",
+      "integrity": "sha512-8eKhFzZp7Qcq1VLfoC75ggGT8nQs9q8fIxltU47yCB7Wi7Y8Qf6oqY1Bm0z04fIec24vEgr0ENhDHEOUGVDqnA==",
       "dev": true,
       "requires": {
-        "@ava/babel-plugin-throws-helper": "^2.0.0",
-        "babel-plugin-espower": "^2.3.2"
-      }
-    },
-    "@ava/write-file-atomic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
-      "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
+        "@ava/babel-plugin-throws-helper": "4.0.0",
+        "babel-plugin-espower": "3.0.1"
       }
     },
     "@babel/code-frame": {
@@ -77,7 +39,29 @@
       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.5.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+      "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.5.5",
+        "@babel/generator": "7.6.0",
+        "@babel/helpers": "7.6.0",
+        "@babel/parser": "7.6.0",
+        "@babel/template": "7.6.0",
+        "@babel/traverse": "7.6.0",
+        "@babel/types": "7.6.1",
+        "convert-source-map": "1.6.0",
+        "debug": "4.1.1",
+        "json5": "2.1.0",
+        "lodash": "4.17.15",
+        "resolve": "1.12.0",
+        "semver": "5.5.0",
+        "source-map": "0.5.7"
       }
     },
     "@babel/generator": {
@@ -86,11 +70,11 @@
       "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.6.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.6.1",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.15",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -101,15 +85,24 @@
         }
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.6.1"
+      }
+    },
     "@babel/helper-function-name": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.6.0",
+        "@babel/types": "7.6.1"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -118,7 +111,68 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.6.1"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.6.1"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+      "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.4.4",
+        "@babel/template": "7.6.0",
+        "@babel/types": "7.6.1",
+        "lodash": "4.17.15"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.15"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-wrap-function": "7.2.0",
+        "@babel/template": "7.6.0",
+        "@babel/traverse": "7.6.0",
+        "@babel/types": "7.6.1"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.6.0",
+        "@babel/types": "7.6.1"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -127,7 +181,30 @@
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "7.6.1"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+      "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/template": "7.6.0",
+        "@babel/traverse": "7.6.0",
+        "@babel/types": "7.6.1"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
+      "integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.6.0",
+        "@babel/traverse": "7.6.0",
+        "@babel/types": "7.6.1"
       }
     },
     "@babel/highlight": {
@@ -136,9 +213,9 @@
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "js-tokens": {
@@ -155,15 +232,96 @@
       "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
       "dev": true
     },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0",
+        "@babel/plugin-syntax-async-generators": "7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+      "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+      "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.5.5",
+        "regexpu-core": "4.6.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+      "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.5.5",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0",
+        "babel-plugin-dynamic-import-node": "2.3.0"
+      }
+    },
     "@babel/template": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
       "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0"
+        "@babel/code-frame": "7.5.5",
+        "@babel/parser": "7.6.0",
+        "@babel/types": "7.6.1"
       }
     },
     "@babel/traverse": {
@@ -172,15 +330,15 @@
       "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "@babel/code-frame": "7.5.5",
+        "@babel/generator": "7.6.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.4.4",
+        "@babel/parser": "7.6.0",
+        "@babel/types": "7.6.1",
+        "debug": "4.1.1",
+        "globals": "11.12.0",
+        "lodash": "4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -189,7 +347,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "globals": {
@@ -212,9 +370,9 @@
       "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.15",
+        "to-fast-properties": "2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -226,59 +384,91 @@
       }
     },
     "@concordance/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@concordance/react/-/react-2.0.0.tgz",
+      "integrity": "sha512-huLSkUuM2/P+U0uy2WwlKuixMsTODD8p4JVQBI4VKeopkiN0C7M3N9XYVawb4M+4spN5RrO/eLhk7KoQX6nsfA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1"
-      }
-    },
-    "@ladjs/time-require": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
-      "integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^0.4.0",
-        "date-time": "^0.1.1",
-        "pretty-ms": "^0.2.1",
-        "text-table": "^0.2.0"
+        "arrify": "1.0.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "pretty-ms": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "dev": true,
-          "requires": {
-            "parse-ms": "^0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         }
       }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
+      "integrity": "sha512-wrIBsjA5pl13f0RN4Zx4FNWmU71lv03meGKnqRUoCyan17s4V3WL92f3w3AIuWbNnpcrQyFBU5qMavJoB8d27w==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.2",
+        "run-parallel": "1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
+      "integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.3.tgz",
+      "integrity": "sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.2",
+        "fastq": "1.6.0"
+      }
+    },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "1.0.2"
+      }
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "3.0.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "12.7.5"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
+      "dev": true
     },
     "acorn": {
       "version": "7.0.0",
@@ -298,31 +488,64 @@
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "3.1.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "4.1.0"
+          }
+        }
       }
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-      "dev": true
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+      "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+      "dev": true,
+      "requires": {
+        "type-fest": "0.5.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true
     },
     "ansi-styles": {
@@ -331,17 +554,17 @@
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
+      "integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "normalize-path": "3.0.0",
+        "picomatch": "2.0.7"
       }
     },
     "append-transform": {
@@ -350,7 +573,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^2.0.0"
+        "default-require-extensions": "2.0.0"
       }
     },
     "archy": {
@@ -365,34 +588,13 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "^1.0.1"
-      }
-    },
-    "arr-exclude": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-find-index": {
@@ -407,35 +609,26 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.14.2"
       }
     },
     "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+    "array-uniq": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+      "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
       "dev": true
     },
     "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
     "astral-regex": {
@@ -444,592 +637,309 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "dev": true
-    },
-    "auto-bind": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.0.tgz",
-      "integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA==",
-      "dev": true
-    },
     "ava": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-0.25.0.tgz",
-      "integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-2.4.0.tgz",
+      "integrity": "sha512-CQWtzZZZeU2g4StojRv6MO9RIRi4sLxGSB9+3C3hv0ttUEG1tkJLTLyrBQeFS4WEeK12Z4ovE3f2iPVhSy8elA==",
       "dev": true,
       "requires": {
-        "@ava/babel-preset-stage-4": "^1.1.0",
-        "@ava/babel-preset-transform-test-files": "^3.0.0",
-        "@ava/write-file-atomic": "^2.2.0",
-        "@concordance/react": "^1.0.0",
-        "@ladjs/time-require": "^0.1.4",
-        "ansi-escapes": "^3.0.0",
-        "ansi-styles": "^3.1.0",
-        "arr-flatten": "^1.0.1",
-        "array-union": "^1.0.1",
-        "array-uniq": "^1.0.2",
-        "arrify": "^1.0.0",
-        "auto-bind": "^1.1.0",
-        "ava-init": "^0.2.0",
-        "babel-core": "^6.17.0",
-        "babel-generator": "^6.26.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-        "bluebird": "^3.0.0",
-        "caching-transform": "^1.0.0",
-        "chalk": "^2.0.1",
-        "chokidar": "^1.4.2",
-        "clean-stack": "^1.1.1",
-        "clean-yaml-object": "^0.1.0",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.0.0",
-        "cli-truncate": "^1.0.0",
-        "co-with-promise": "^4.6.0",
-        "code-excerpt": "^2.1.1",
-        "common-path-prefix": "^1.0.0",
-        "concordance": "^3.0.0",
-        "convert-source-map": "^1.5.1",
-        "core-assert": "^0.2.0",
-        "currently-unhandled": "^0.4.1",
-        "debug": "^3.0.1",
-        "dot-prop": "^4.1.0",
-        "empower-core": "^0.6.1",
-        "equal-length": "^1.0.0",
-        "figures": "^2.0.0",
-        "find-cache-dir": "^1.0.0",
-        "fn-name": "^2.0.0",
-        "get-port": "^3.0.0",
-        "globby": "^6.0.0",
-        "has-flag": "^2.0.0",
-        "hullabaloo-config-manager": "^1.1.0",
-        "ignore-by-default": "^1.0.0",
-        "import-local": "^0.1.1",
-        "indent-string": "^3.0.0",
-        "is-ci": "^1.0.7",
-        "is-generator-fn": "^1.0.0",
-        "is-obj": "^1.0.0",
-        "is-observable": "^1.0.0",
-        "is-promise": "^2.1.0",
-        "last-line-stream": "^1.0.0",
-        "lodash.clonedeepwith": "^4.5.0",
-        "lodash.debounce": "^4.0.3",
-        "lodash.difference": "^4.3.0",
-        "lodash.flatten": "^4.2.0",
-        "loud-rejection": "^1.2.0",
-        "make-dir": "^1.0.0",
-        "matcher": "^1.0.0",
-        "md5-hex": "^2.0.0",
-        "meow": "^3.7.0",
-        "ms": "^2.0.0",
-        "multimatch": "^2.1.0",
-        "observable-to-promise": "^0.5.0",
-        "option-chain": "^1.0.0",
-        "package-hash": "^2.0.0",
-        "pkg-conf": "^2.0.0",
-        "plur": "^2.0.0",
-        "pretty-ms": "^3.0.0",
-        "require-precompiled": "^0.1.0",
-        "resolve-cwd": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "semver": "^5.4.1",
-        "slash": "^1.0.0",
-        "source-map-support": "^0.5.0",
-        "stack-utils": "^1.0.1",
-        "strip-ansi": "^4.0.0",
-        "strip-bom-buf": "^1.0.0",
-        "supertap": "^1.0.0",
-        "supports-color": "^5.0.0",
-        "trim-off-newlines": "^1.0.1",
-        "unique-temp-dir": "^1.0.0",
-        "update-notifier": "^2.3.0"
-      }
-    },
-    "ava-init": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
-      "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-      "dev": true,
-      "requires": {
-        "arr-exclude": "^1.0.0",
-        "execa": "^0.7.0",
-        "has-yarn": "^1.0.0",
-        "read-pkg-up": "^2.0.0",
-        "write-pkg": "^3.1.0"
-      }
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "@ava/babel-preset-stage-4": "4.0.0",
+        "@ava/babel-preset-transform-test-files": "6.0.0",
+        "@babel/core": "7.6.0",
+        "@babel/generator": "7.6.0",
+        "@concordance/react": "2.0.0",
+        "ansi-escapes": "4.2.1",
+        "ansi-styles": "4.1.0",
+        "arr-flatten": "1.1.0",
+        "array-union": "2.1.0",
+        "array-uniq": "2.1.0",
+        "arrify": "2.0.1",
+        "bluebird": "3.5.5",
+        "chalk": "2.4.2",
+        "chokidar": "3.1.0",
+        "chunkd": "1.0.0",
+        "ci-parallel-vars": "1.0.0",
+        "clean-stack": "2.2.0",
+        "clean-yaml-object": "0.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-truncate": "2.0.0",
+        "code-excerpt": "2.1.1",
+        "common-path-prefix": "1.0.0",
+        "concordance": "4.0.0",
+        "convert-source-map": "1.6.0",
+        "currently-unhandled": "0.4.1",
+        "debug": "4.1.1",
+        "del": "4.1.1",
+        "dot-prop": "5.1.0",
+        "emittery": "0.4.1",
+        "empower-core": "1.2.0",
+        "equal-length": "1.0.1",
+        "escape-string-regexp": "2.0.0",
+        "esm": "3.2.25",
+        "figures": "3.0.0",
+        "find-up": "4.1.0",
+        "get-port": "5.0.0",
+        "globby": "10.0.1",
+        "ignore-by-default": "1.0.1",
+        "import-local": "3.0.2",
+        "indent-string": "4.0.0",
+        "is-ci": "2.0.0",
+        "is-error": "2.2.2",
+        "is-observable": "2.0.0",
+        "is-plain-object": "3.0.0",
+        "is-promise": "2.1.0",
+        "lodash": "4.17.15",
+        "loud-rejection": "2.1.0",
+        "make-dir": "3.0.0",
+        "matcher": "2.0.0",
+        "md5-hex": "3.0.1",
+        "meow": "5.0.0",
+        "micromatch": "4.0.2",
+        "ms": "2.1.2",
+        "observable-to-promise": "1.0.0",
+        "ora": "3.4.0",
+        "package-hash": "4.0.0",
+        "pkg-conf": "3.1.0",
+        "plur": "3.1.1",
+        "pretty-ms": "5.0.0",
+        "require-precompiled": "0.1.0",
+        "resolve-cwd": "3.0.0",
+        "slash": "3.0.0",
+        "source-map-support": "0.5.13",
+        "stack-utils": "1.0.2",
+        "strip-ansi": "5.2.0",
+        "strip-bom-buf": "2.0.0",
+        "supertap": "1.0.0",
+        "supports-color": "7.0.0",
+        "trim-off-newlines": "1.0.1",
+        "trim-right": "1.0.1",
+        "unique-temp-dir": "1.0.0",
+        "update-notifier": "3.0.1",
+        "write-file-atomic": "3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.1.0.tgz",
+          "integrity": "sha512-Qts4KCLKG+waHc9C4m07weIY8qyeixoS0h6RnbsNVD6Fw+pEZGW3vTyObL3WXpE09Mq4Oi7/lBEyLmOiLtlYWQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "color-convert": "2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "1.9.3"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "3.0.0"
+              }
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "3.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          },
+          "dependencies": {
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            }
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "5.0.0",
+            "path-exists": "4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "4.1.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "2.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "2.2.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "2.2.1"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "5.1.0",
+            "signal-exit": "3.0.2"
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
     },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
+        "object.assign": "4.1.0"
       }
     },
     "babel-plugin-espower": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
-      "integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz",
+      "integrity": "sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.1.0",
-        "babylon": "^6.1.0",
-        "call-matcher": "^1.0.0",
-        "core-js": "^2.0.0",
-        "espower-location-detector": "^1.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.1.1"
+        "@babel/generator": "7.6.0",
+        "@babel/parser": "7.6.0",
+        "call-matcher": "1.1.0",
+        "core-js": "2.6.9",
+        "espower-location-detector": "1.0.0",
+        "espurify": "1.8.1",
+        "estraverse": "4.2.0"
       }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1038,37 +948,99 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "dev": true
+    },
+    "blueimp-md5": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.12.0.tgz",
+      "integrity": "sha512-zo+HIdIhzojv6F1siQPqPFROyVy7C50KzHv/k/Iz+BtvtVzSHXiMXOpq2wCfNkeBqdCv+V8XOV96tsEt2W/3rQ==",
       "dev": true
     },
     "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "3.0.0",
+        "camelcase": "5.3.1",
+        "chalk": "2.4.2",
+        "cli-boxes": "2.2.0",
+        "string-width": "3.1.0",
+        "term-size": "1.2.0",
+        "type-fest": "0.3.1",
+        "widest-line": "2.0.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
         }
       }
     },
@@ -1078,25 +1050,23 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "fill-range": "7.0.1"
       }
     },
-    "buf-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -1105,49 +1075,48 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
-    "caching-transform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-      "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "dev": true,
       "requires": {
-        "md5-hex": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "write-file-atomic": "^1.1.4"
+        "clone-response": "1.0.2",
+        "get-stream": "5.1.0",
+        "http-cache-semantics": "4.0.3",
+        "keyv": "3.1.0",
+        "lowercase-keys": "2.0.0",
+        "normalize-url": "4.3.0",
+        "responselike": "1.0.2"
       },
       "dependencies": {
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "pump": "3.0.0"
           }
         },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
-          }
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
         }
       }
     },
     "call-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
+      "integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "deep-equal": "^1.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.0.0"
+        "core-js": "2.6.9",
+        "deep-equal": "1.1.0",
+        "espurify": "1.8.1",
+        "estraverse": "4.2.0"
       }
     },
     "call-signature": {
@@ -1163,26 +1132,21 @@
       "dev": true
     },
     "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "4.1.0",
+        "map-obj": "2.0.0",
+        "quick-lru": "1.1.0"
       }
-    },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
     },
     "chalk": {
       "version": "2.3.0",
@@ -1190,9 +1154,9 @@
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^4.0.0"
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.5.0"
       },
       "dependencies": {
         "supports-color": {
@@ -1201,7 +1165,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -1213,32 +1177,42 @@
       "dev": true
     },
     "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.1.0.tgz",
+      "integrity": "sha512-6vZfo+7W0EOlbSo0nhVKMz4yyssrwiPbBZ8wj1lq8/+l4ZhGZ2U4Md7PspvmijXp1a26D3B7AHEBmIB7aVtaOQ==",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "3.1.0",
+        "braces": "3.0.2",
+        "glob-parent": "5.0.0",
+        "is-binary-path": "2.1.0",
+        "is-glob": "4.0.1",
+        "normalize-path": "3.0.0",
+        "readdirp": "3.1.2"
       }
     },
+    "chunkd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
+      "integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==",
+      "dev": true
+    },
     "ci-info": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "ci-parallel-vars": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz",
+      "integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==",
       "dev": true
     },
     "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
     "clean-yaml-object": {
@@ -1248,9 +1222,9 @@
       "dev": true
     },
     "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
       "dev": true
     },
     "cli-cursor": {
@@ -1259,23 +1233,57 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
+      "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
       "dev": true
     },
     "cli-truncate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
-      "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.0.0.tgz",
+      "integrity": "sha512-C4hp+8GCIFVsUUiXcw+ce+7wexVWImw8rQrgMBFsqerx9LvvcGlwm6sMjQYAEmV/Xb87xc1b5Ttx505MSpZVqg==",
       "dev": true,
       "requires": {
-        "slice-ansi": "^1.0.0",
-        "string-width": "^2.0.0"
+        "slice-ansi": "2.1.0",
+        "string-width": "4.1.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "8.0.0",
+            "is-fullwidth-code-point": "3.0.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "4.1.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -1290,9 +1298,9 @@
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "3.1.0",
+        "strip-ansi": "5.2.0",
+        "wrap-ansi": "5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1307,9 +1315,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -1318,18 +1326,24 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
     },
-    "co-with-promise": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
-      "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "code-excerpt": {
@@ -1338,7 +1352,7 @@
       "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
       "dev": true,
       "requires": {
-        "convert-to-spaces": "^1.0.1"
+        "convert-to-spaces": "1.0.2"
       }
     },
     "color-convert": {
@@ -1347,7 +1361,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -1382,47 +1396,96 @@
       "dev": true
     },
     "concordance": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
-      "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-4.0.0.tgz",
+      "integrity": "sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==",
       "dev": true,
       "requires": {
-        "date-time": "^2.1.0",
-        "esutils": "^2.0.2",
-        "fast-diff": "^1.1.1",
-        "function-name-support": "^0.2.0",
-        "js-string-escape": "^1.0.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flattendeep": "^4.4.0",
-        "lodash.merge": "^4.6.0",
-        "md5-hex": "^2.0.0",
-        "semver": "^5.3.0",
-        "well-known-symbols": "^1.0.0"
+        "date-time": "2.1.0",
+        "esutils": "2.0.2",
+        "fast-diff": "1.2.0",
+        "js-string-escape": "1.0.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.flattendeep": "4.4.0",
+        "lodash.islength": "4.0.1",
+        "lodash.merge": "4.6.2",
+        "md5-hex": "2.0.0",
+        "semver": "5.7.1",
+        "well-known-symbols": "2.0.0"
       },
       "dependencies": {
-        "date-time": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-          "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+        "md5-hex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+          "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
           "dev": true,
           "requires": {
-            "time-zone": "^1.0.0"
+            "md5-o-matic": "0.1.1"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.4.3",
+        "xdg-basedir": "3.0.0"
+      },
+      "dependencies": {
+        "dot-prop": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          }
+        }
       }
     },
     "contains-path": {
@@ -1432,10 +1495,13 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "convert-to-spaces": {
       "version": "1.0.2",
@@ -1443,26 +1509,10 @@
       "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
       "dev": true
     },
-    "core-assert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
-      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "dev": true,
-      "requires": {
-        "buf-compare": "^1.0.0",
-        "is-error": "^2.2.0"
-      }
-    },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
       "dev": true
     },
     "cp-file": {
@@ -1471,11 +1521,11 @@
       "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
+        "graceful-fs": "4.1.11",
+        "make-dir": "2.1.0",
+        "nested-error-stacks": "2.1.0",
+        "pify": "4.0.1",
+        "safe-buffer": "5.1.1"
       },
       "dependencies": {
         "make-dir": {
@@ -1484,8 +1534,8 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "pify": "4.0.1",
+            "semver": "5.7.1"
           }
         },
         "pify": {
@@ -1502,24 +1552,15 @@
         }
       }
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "crypto-random-string": {
@@ -1534,22 +1575,33 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "date-time": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-      "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-      "dev": true
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "time-zone": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "debug-log": {
@@ -1564,11 +1616,46 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
+    },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "1.0.4",
+        "is-date-object": "1.0.1",
+        "is-regex": "1.0.4",
+        "object-is": "1.0.1",
+        "object-keys": "1.1.1",
+        "regexp.prototype.flags": "1.2.0"
+      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -1588,8 +1675,23 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "^3.0.0"
+        "strip-bom": "3.0.0"
       }
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.4"
+      }
+    },
+    "defer-to-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1597,7 +1699,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.1"
       }
     },
     "deglob": {
@@ -1606,12 +1708,12 @@
       "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
       "dev": true,
       "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^5.0.0",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
+        "find-root": "1.1.0",
+        "glob": "7.1.2",
+        "ignore": "5.1.4",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.9",
+        "uniq": "1.0.1"
       },
       "dependencies": {
         "ignore": {
@@ -1622,13 +1724,80 @@
         }
       }
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+    "del": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "@types/glob": "7.1.1",
+        "globby": "6.1.0",
+        "is-path-cwd": "2.2.0",
+        "is-path-in-cwd": "2.1.0",
+        "p-map": "2.1.0",
+        "pify": "4.0.1",
+        "rimraf": "2.6.3"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "dev": true,
+          "requires": {
+            "array-uniq": "1.0.3"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+          "dev": true
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
       }
     },
     "doctrine": {
@@ -1637,22 +1806,28 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
+      "integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "2.0.0"
       }
     },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
+      "integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -1662,13 +1837,22 @@
       "dev": true
     },
     "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
+      "integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "^2.0.0"
+        "core-js": "2.6.9"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
       }
     },
     "equal-length": {
@@ -1683,7 +1867,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -1692,16 +1876,16 @@
       "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.0",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-inspect": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "has-symbols": "1.0.0",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4",
+        "object-inspect": "1.6.0",
+        "object-keys": "1.1.1",
+        "string.prototype.trimleft": "2.1.0",
+        "string.prototype.trimright": "2.1.0"
       }
     },
     "es-to-primitive": {
@@ -1710,9 +1894,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "es6-error": {
@@ -1733,43 +1917,43 @@
       "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
-        "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
-        "table": "^5.2.3",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "@babel/code-frame": "7.5.5",
+        "ajv": "6.10.2",
+        "chalk": "2.3.0",
+        "cross-spawn": "6.0.5",
+        "debug": "4.1.1",
+        "doctrine": "3.0.0",
+        "eslint-scope": "5.0.0",
+        "eslint-utils": "1.4.2",
+        "eslint-visitor-keys": "1.1.0",
+        "espree": "6.1.1",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "5.0.1",
+        "functional-red-black-tree": "1.0.1",
+        "glob-parent": "5.0.0",
+        "globals": "11.12.0",
+        "ignore": "4.0.6",
+        "import-fresh": "3.1.0",
+        "imurmurhash": "0.1.4",
+        "inquirer": "6.5.2",
+        "is-glob": "4.0.1",
+        "js-yaml": "3.13.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.15",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "progress": "2.0.3",
+        "regexpp": "2.0.1",
+        "semver": "6.3.0",
+        "strip-ansi": "5.2.0",
+        "strip-json-comments": "3.0.1",
+        "table": "5.4.6",
+        "text-table": "0.2.0",
+        "v8-compile-cache": "2.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1778,7 +1962,7 @@
           "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.0.0"
+            "@babel/highlight": "7.5.0"
           }
         },
         "@babel/highlight": {
@@ -1787,9 +1971,9 @@
           "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
+            "chalk": "2.3.0",
+            "esutils": "2.0.2",
+            "js-tokens": "4.0.0"
           }
         },
         "ansi-regex": {
@@ -1804,11 +1988,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.7.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "semver": {
@@ -1825,7 +2009,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "glob-parent": {
@@ -1834,7 +2018,7 @@
           "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
           "dev": true,
           "requires": {
-            "is-glob": "^4.0.1"
+            "is-glob": "4.0.1"
           }
         },
         "globals": {
@@ -1855,7 +2039,7 @@
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "js-tokens": {
@@ -1882,7 +2066,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         },
         "strip-json-comments": {
@@ -1911,8 +2095,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.12.0"
       },
       "dependencies": {
         "debug": {
@@ -1932,8 +2116,8 @@
       "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^2.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1953,8 +2137,8 @@
       "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^1.4.2",
-        "regexpp": "^3.0.0"
+        "eslint-utils": "1.4.2",
+        "regexpp": "3.0.0"
       },
       "dependencies": {
         "regexpp": {
@@ -1971,17 +2155,17 @@
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.9",
+        "array-includes": "3.0.3",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.0",
-        "has": "^1.0.3",
-        "minimatch": "^3.0.4",
-        "object.values": "^1.1.0",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.11.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.4.1",
+        "has": "1.0.3",
+        "minimatch": "3.0.4",
+        "object.values": "1.1.0",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.12.0"
       },
       "dependencies": {
         "debug": {
@@ -1999,8 +2183,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         }
       }
@@ -2011,12 +2195,12 @@
       "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^2.0.0",
-        "eslint-utils": "^1.4.2",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "eslint-plugin-es": "2.0.0",
+        "eslint-utils": "1.4.2",
+        "ignore": "5.1.4",
+        "minimatch": "3.0.4",
+        "resolve": "1.12.0",
+        "semver": "6.3.0"
       },
       "dependencies": {
         "ignore": {
@@ -2045,15 +2229,15 @@
       "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.1.0",
-        "object.entries": "^1.1.0",
-        "object.fromentries": "^2.0.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "resolve": "^1.10.1"
+        "array-includes": "3.0.3",
+        "doctrine": "2.1.0",
+        "has": "1.0.3",
+        "jsx-ast-utils": "2.2.1",
+        "object.entries": "1.1.0",
+        "object.fromentries": "2.0.0",
+        "object.values": "1.1.0",
+        "prop-types": "15.7.2",
+        "resolve": "1.12.0"
       },
       "dependencies": {
         "doctrine": {
@@ -2062,7 +2246,7 @@
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2"
+            "esutils": "2.0.2"
           }
         }
       }
@@ -2079,8 +2263,8 @@
       "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -2089,7 +2273,7 @@
       "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -2098,16 +2282,22 @@
       "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
+    },
     "espower-location-detector": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "^1.2.1",
-        "path-is-absolute": "^1.0.0",
-        "source-map": "^0.5.0",
-        "xtend": "^4.0.0"
+        "is-url": "1.2.4",
+        "path-is-absolute": "1.0.1",
+        "source-map": "0.5.7",
+        "xtend": "4.0.1"
       }
     },
     "espree": {
@@ -2116,9 +2306,9 @@
       "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
-        "eslint-visitor-keys": "^1.1.0"
+        "acorn": "7.0.0",
+        "acorn-jsx": "5.0.2",
+        "eslint-visitor-keys": "1.1.0"
       }
     },
     "esprima": {
@@ -2128,12 +2318,12 @@
       "dev": true
     },
     "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+      "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0"
+        "core-js": "2.6.9"
       }
     },
     "esquery": {
@@ -2142,7 +2332,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -2151,7 +2341,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -2172,31 +2362,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "^0.1.0"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "^2.1.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "external-editor": {
@@ -2205,18 +2377,9 @@
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^1.0.0"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -2226,10 +2389,24 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
+    },
+    "fast-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
+      "integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.2",
+        "@nodelib/fs.walk": "1.2.3",
+        "glob-parent": "5.0.0",
+        "is-glob": "4.0.1",
+        "merge2": "1.3.0",
+        "micromatch": "4.0.2"
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -2243,13 +2420,22 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "1.0.4"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -2258,37 +2444,16 @@
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "2.0.1"
       }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
     },
     "fill-range": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "find-cache-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^2.0.0"
+        "to-regex-range": "5.0.1"
       }
     },
     "find-root": {
@@ -2303,7 +2468,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "flat-cache": {
@@ -2312,7 +2477,7 @@
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
+        "flatted": "2.0.1",
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
@@ -2323,35 +2488,14 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-      "dev": true
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "^1.0.1"
-      }
-    },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
       },
       "dependencies": {
         "cross-spawn": {
@@ -2360,8 +2504,8 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
           }
         }
       }
@@ -2372,564 +2516,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "function-name-support": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-      "integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -2945,16 +2535,13 @@
       "dev": true
     },
     "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
+      "integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "0.3.1"
+      }
     },
     "get-stream": {
       "version": "3.0.0",
@@ -2968,31 +2555,21 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "4.0.1"
       }
     },
     "global-dirs": {
@@ -3001,62 +2578,75 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
-    },
     "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "@types/glob": "7.1.1",
+        "array-union": "2.1.0",
+        "dir-glob": "3.0.1",
+        "fast-glob": "3.0.4",
+        "glob": "7.1.4",
+        "ignore": "5.1.4",
+        "merge2": "1.3.0",
+        "slash": "3.0.0"
       },
       "dependencies": {
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
         }
       }
     },
     "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "@sindresorhus/is": "0.14.0",
+        "@szmarczak/http-timer": "1.1.2",
+        "cacheable-request": "6.1.0",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "4.1.0",
+        "lowercase-keys": "1.0.1",
+        "mimic-response": "1.0.1",
+        "p-cancelable": "1.1.0",
+        "to-readable-stream": "1.0.0",
+        "url-parse-lax": "3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "3.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -3071,10 +2661,10 @@
       "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
       "dev": true,
       "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "neo-async": "2.6.1",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -3091,23 +2681,8 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
     },
     "has-flag": {
       "version": "2.0.0",
@@ -3122,9 +2697,9 @@
       "dev": true
     },
     "has-yarn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
     "hasha": {
@@ -3133,17 +2708,7 @@
       "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1"
-      }
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "is-stream": "1.1.0"
       }
     },
     "hosted-git-info": {
@@ -3152,27 +2717,11 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
-    "hullabaloo-config-manager": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
-      "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-      "dev": true,
-      "requires": {
-        "dot-prop": "^4.1.0",
-        "es6-error": "^4.0.2",
-        "graceful-fs": "^4.1.11",
-        "indent-string": "^3.1.0",
-        "json5": "^0.5.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.clonedeepwith": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.merge": "^4.6.0",
-        "md5-hex": "^2.0.0",
-        "package-hash": "^2.0.0",
-        "pkg-dir": "^2.0.0",
-        "resolve-from": "^3.0.0",
-        "safe-buffer": "^5.0.1"
-      }
+    "http-cache-semantics": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -3180,7 +2729,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -3201,8 +2750,8 @@
       "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
       "dev": true,
       "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
+        "parent-module": "1.0.1",
+        "resolve-from": "4.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -3220,13 +2769,67 @@
       "dev": true
     },
     "import-local": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
-      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "4.2.0",
+        "resolve-cwd": "3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "5.0.0",
+            "path-exists": "4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "2.2.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "2.2.1"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "4.1.0"
+          }
+        }
       }
     },
     "imurmurhash": {
@@ -3236,9 +2839,9 @@
       "dev": true
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -3247,8 +2850,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -3269,19 +2872,19 @@
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.15",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "6.5.3",
+        "string-width": "2.1.1",
+        "strip-ansi": "5.2.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -3302,7 +2905,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -3311,9 +2914,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "has-flag": {
@@ -3328,7 +2931,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         },
         "supports-color": {
@@ -3337,24 +2940,21 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "irregular-plurals": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
+      "integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
       "dev": true
     },
     "is-arrayish": {
@@ -3364,19 +2964,13 @@
       "dev": true
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "2.0.0"
       }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3384,7 +2978,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -3394,12 +2988,12 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "2.0.0"
       }
     },
     "is-date-object": {
@@ -3408,47 +3002,17 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
     "is-error": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-      "dev": true
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
+      "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
       "dev": true
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -3456,19 +3020,13 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
-    "is-generator-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-      "dev": true
-    },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-installed-globally": {
@@ -3477,47 +3035,67 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        }
       }
     },
     "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
       "dev": true
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2"
-      }
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
     "is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.0.0.tgz",
+      "integrity": "sha512-fhBZv3eFKUbyHXZ1oHujdo2tZ+CNbdpdzzlENgCGZUC8keoGxUew2jYFLYcUB4qo7LDD03o4KK11m/QYD7kEjg==",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
       "dev": true,
       "requires": {
-        "symbol-observable": "^1.1.0"
+        "is-path-inside": "2.1.0"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+      "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -3526,28 +3104,19 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+    "is-plain-object": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+      "dev": true,
+      "requires": {
+        "isobject": "4.0.0"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
@@ -3556,14 +3125,8 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3577,19 +3140,31 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "is-url": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
     "isarray": {
@@ -3605,13 +3180,10 @@
       "dev": true
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -3625,7 +3197,7 @@
       "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
       "dev": true,
       "requires": {
-        "append-transform": "^1.0.0"
+        "append-transform": "1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -3634,13 +3206,13 @@
       "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
+        "@babel/generator": "7.6.0",
+        "@babel/parser": "7.6.0",
+        "@babel/template": "7.6.0",
+        "@babel/traverse": "7.6.0",
+        "@babel/types": "7.6.1",
+        "istanbul-lib-coverage": "2.0.5",
+        "semver": "6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -3657,9 +3229,9 @@
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
+        "istanbul-lib-coverage": "2.0.5",
+        "make-dir": "2.1.0",
+        "supports-color": "6.1.0"
       },
       "dependencies": {
         "has-flag": {
@@ -3674,8 +3246,8 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "pify": "4.0.1",
+            "semver": "5.7.1"
           }
         },
         "pify": {
@@ -3696,7 +3268,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3707,11 +3279,11 @@
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
+        "debug": "4.1.1",
+        "istanbul-lib-coverage": "2.0.5",
+        "make-dir": "2.1.0",
+        "rimraf": "2.6.3",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "debug": {
@@ -3720,7 +3292,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "make-dir": {
@@ -3729,8 +3301,8 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "pify": "4.0.1",
+            "semver": "5.7.1"
           }
         },
         "ms": {
@@ -3765,7 +3337,7 @@
       "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "handlebars": "4.2.0"
       }
     },
     "js-string-escape": {
@@ -3786,14 +3358,20 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -3815,10 +3393,21 @@
       "dev": true
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "jsx-ast-utils": {
       "version": "2.2.1",
@@ -3826,35 +3415,26 @@
       "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "object.assign": "^4.1.0"
+        "array-includes": "3.0.3",
+        "object.assign": "4.1.0"
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "last-line-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
-      "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.0"
+        "json-buffer": "3.0.0"
       }
     },
     "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "6.5.0"
       }
     },
     "levn": {
@@ -3863,8 +3443,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -3873,10 +3453,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -3885,8 +3465,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -3901,40 +3481,16 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.clonedeepwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-      "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
-      "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+    "lodash.islength": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
+      "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
       "dev": true
     },
     "lodash.merge": {
@@ -3943,29 +3499,29 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "chalk": "2.3.0"
       }
     },
     "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.1.0.tgz",
+      "integrity": "sha512-g/6MQxUXYHeVqZ4PGpPL1fS1fOvlXoi7bay0pizmjAd/3JhyXwxzwrnr74yzdmhuerlslbRJ3x7IOXzFz0cE5w==",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -3974,55 +3530,57 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "semver": "6.3.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
     },
     "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
     "matcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.0.0.tgz",
-      "integrity": "sha1-qvDEgW62m5IJRnQXViXzRmsOPhk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
+      "integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.4"
+        "escape-string-regexp": "2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
       }
     },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
-    },
     "md5-hex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
-      "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
+      "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
       "dev": true,
       "requires": {
-        "md5-o-matic": "^0.1.1"
+        "blueimp-md5": "2.12.0"
       }
     },
     "md5-o-matic": {
@@ -4032,115 +3590,97 @@
       "dev": true
     },
     "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "4.2.0",
+        "decamelize-keys": "1.1.0",
+        "loud-rejection": "1.6.0",
+        "minimist-options": "3.0.2",
+        "normalize-package-data": "2.4.0",
+        "read-pkg-up": "3.0.0",
+        "redent": "2.0.0",
+        "trim-newlines": "2.0.0",
+        "yargs-parser": "10.1.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
         "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+        "loud-rejection": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "currently-unhandled": "0.4.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "pify": "3.0.0"
           }
         },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
-        },
         "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -4151,7 +3691,7 @@
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -4162,25 +3702,20 @@
         }
       }
     },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
+    },
     "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "braces": "3.0.2",
+        "picomatch": "2.0.7"
       }
     },
     "mimic-fn": {
@@ -4189,13 +3724,19 @@
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -4203,6 +3744,24 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -4219,30 +3778,11 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
-      }
-    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
-      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4274,20 +3814,23 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -4295,14 +3838,8 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
     },
     "nyc": {
       "version": "14.1.1",
@@ -4310,31 +3847,31 @@
       "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "caching-transform": "^3.0.2",
-        "convert-source-map": "^1.6.0",
-        "cp-file": "^6.2.0",
-        "find-cache-dir": "^2.1.0",
-        "find-up": "^3.0.0",
-        "foreground-child": "^1.5.6",
-        "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.5",
-        "istanbul-lib-hook": "^2.0.7",
-        "istanbul-lib-instrument": "^3.3.0",
-        "istanbul-lib-report": "^2.0.8",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.4",
-        "js-yaml": "^3.13.1",
-        "make-dir": "^2.1.0",
-        "merge-source-map": "^1.1.0",
-        "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.3",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.2.3",
-        "uuid": "^3.3.2",
-        "yargs": "^13.2.2",
-        "yargs-parser": "^13.0.0"
+        "archy": "1.0.0",
+        "caching-transform": "3.0.2",
+        "convert-source-map": "1.6.0",
+        "cp-file": "6.2.0",
+        "find-cache-dir": "2.1.0",
+        "find-up": "3.0.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.4",
+        "istanbul-lib-coverage": "2.0.5",
+        "istanbul-lib-hook": "2.0.7",
+        "istanbul-lib-instrument": "3.3.0",
+        "istanbul-lib-report": "2.0.8",
+        "istanbul-lib-source-maps": "3.0.6",
+        "istanbul-reports": "2.2.6",
+        "js-yaml": "3.13.1",
+        "make-dir": "2.1.0",
+        "merge-source-map": "1.1.0",
+        "resolve-from": "4.0.0",
+        "rimraf": "2.6.3",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.3",
+        "test-exclude": "5.2.3",
+        "uuid": "3.3.3",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1"
       },
       "dependencies": {
         "caching-transform": {
@@ -4343,10 +3880,10 @@
           "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
           "dev": true,
           "requires": {
-            "hasha": "^3.0.0",
-            "make-dir": "^2.0.0",
-            "package-hash": "^3.0.0",
-            "write-file-atomic": "^2.4.2"
+            "hasha": "3.0.0",
+            "make-dir": "2.1.0",
+            "package-hash": "3.0.0",
+            "write-file-atomic": "2.4.3"
           }
         },
         "convert-source-map": {
@@ -4355,7 +3892,7 @@
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "find-cache-dir": {
@@ -4364,9 +3901,9 @@
           "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^2.0.0",
-            "pkg-dir": "^3.0.0"
+            "commondir": "1.0.1",
+            "make-dir": "2.1.0",
+            "pkg-dir": "3.0.0"
           }
         },
         "find-up": {
@@ -4375,7 +3912,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "glob": {
@@ -4384,12 +3921,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -4404,8 +3941,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "make-dir": {
@@ -4414,8 +3951,8 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "pify": "4.0.1",
+            "semver": "5.7.1"
           }
         },
         "p-limit": {
@@ -4424,7 +3961,7 @@
           "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -4433,7 +3970,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.1"
           }
         },
         "package-hash": {
@@ -4442,10 +3979,10 @@
           "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.15",
-            "hasha": "^3.0.0",
-            "lodash.flattendeep": "^4.4.0",
-            "release-zalgo": "^1.0.0"
+            "graceful-fs": "4.2.2",
+            "hasha": "3.0.0",
+            "lodash.flattendeep": "4.4.0",
+            "release-zalgo": "1.0.0"
           }
         },
         "pify": {
@@ -4460,7 +3997,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "3.0.0"
           }
         },
         "resolve-from": {
@@ -4481,9 +4018,9 @@
           "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.2.2",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           }
         }
       }
@@ -4500,6 +4037,12 @@
       "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -4512,10 +4055,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.1.1"
       }
     },
     "object.entries": {
@@ -4524,10 +4067,10 @@
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.14.2",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "object.fromentries": {
@@ -4536,20 +4079,10 @@
       "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1"
-      }
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.14.2",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "object.values": {
@@ -4558,39 +4091,20 @@
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.14.2",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "observable-to-promise": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
-      "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-1.0.0.tgz",
+      "integrity": "sha512-cqnGUrNsE6vdVDTPAX9/WeVzwy/z37vdxupdQXU8vgTXRFH72KCZiZga8aca2ulRPIeem8W3vW9rQHBwfIl2WA==",
       "dev": true,
       "requires": {
-        "is-observable": "^0.2.0",
-        "symbol-observable": "^1.0.4"
-      },
-      "dependencies": {
-        "is-observable": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
-          "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-          "dev": true,
-          "requires": {
-            "symbol-observable": "^0.2.2"
-          },
-          "dependencies": {
-            "symbol-observable": {
-              "version": "0.2.4",
-              "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-              "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-              "dev": true
-            }
-          }
-        }
+        "is-observable": "2.0.0",
+        "symbol-observable": "1.2.0"
       }
     },
     "once": {
@@ -4599,7 +4113,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -4608,7 +4122,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.1.0"
       }
     },
     "optimist": {
@@ -4617,8 +4131,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "wordwrap": {
@@ -4629,24 +4143,78 @@
         }
       }
     },
-    "option-chain": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-      "integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-      "dev": true
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "2.2.0",
+        "log-symbols": "2.2.0",
+        "strip-ansi": "5.2.0",
+        "wcwidth": "1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "os-homedir": {
@@ -4659,6 +4227,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
     "p-finally": {
@@ -4679,8 +4253,14 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true
     },
     "p-try": {
       "version": "2.2.0",
@@ -4689,27 +4269,53 @@
       "dev": true
     },
     "package-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
-      "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "lodash.flattendeep": "^4.4.0",
-        "md5-hex": "^2.0.0",
-        "release-zalgo": "^1.0.0"
+        "graceful-fs": "4.2.2",
+        "hasha": "5.0.0",
+        "lodash.flattendeep": "4.4.0",
+        "release-zalgo": "1.0.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
+        },
+        "hasha": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
+          "integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
+          "dev": true,
+          "requires": {
+            "is-stream": "1.1.0",
+            "type-fest": "0.3.1"
+          }
+        }
       }
     },
     "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "9.6.0",
+        "registry-auth-token": "4.0.0",
+        "registry-url": "5.1.0",
+        "semver": "6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "parent-module": {
@@ -4718,19 +4324,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
-        "callsites": "^3.0.0"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "callsites": "3.1.0"
       }
     },
     "parse-json": {
@@ -4739,13 +4333,13 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-ms": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-      "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
       "dev": true
     },
     "path-exists": {
@@ -4784,8 +4378,14 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
+    },
+    "picomatch": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -4794,28 +4394,102 @@
       "dev": true
     },
     "pinkie": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-      "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-      "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^1.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-conf": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
-      "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^2.0.0"
+        "find-up": "3.0.0",
+        "load-json-file": "5.3.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.2.2",
+            "parse-json": "4.0.0",
+            "pify": "4.0.1",
+            "strip-bom": "3.0.0",
+            "type-fest": "0.3.1"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "2.2.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "2.2.1"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "pkg-config": {
@@ -4824,9 +4498,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
       }
     },
     "pkg-dir": {
@@ -4835,16 +4509,16 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       }
     },
     "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
+      "integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "2.0.0"
       }
     },
     "prelude-ls": {
@@ -4854,46 +4528,19 @@
       "dev": true
     },
     "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "pretty-ms": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
-      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.0.0.tgz",
+      "integrity": "sha512-94VRYjL9k33RzfKiGokPBPpsmloBYSf5Ri+Pq19zlsEcUKFob+admeXr5eFDRuPjFmEOcjJvPGdillYOJyvZ7Q==",
       "dev": true,
       "requires": {
-        "parse-ms": "^1.0.0",
-        "plur": "^2.1.2"
-      },
-      "dependencies": {
-        "parse-ms": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-          "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-          "dev": true
-        }
+        "parse-ms": "2.1.0"
       }
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -4907,9 +4554,9 @@
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "react-is": "16.9.0"
       },
       "dependencies": {
         "loose-envify": {
@@ -4918,7 +4565,7 @@
           "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
+            "js-tokens": "3.0.2"
           }
         }
       }
@@ -4929,36 +4576,27 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
     },
     "rc": {
       "version": "1.2.8",
@@ -4966,10 +4604,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -4992,9 +4630,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -5003,77 +4641,59 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
+      "integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "picomatch": "2.0.7"
       }
     },
     "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "3.2.0",
+        "strip-indent": "2.0.0"
       },
       "dependencies": {
         "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
         }
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+    "regenerate-unicode-properties": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "regenerate": "1.4.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.3"
       }
     },
     "regexpp": {
@@ -5083,48 +4703,51 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "8.1.0",
+        "regjsgen": "0.5.0",
+        "regjsparser": "0.6.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.1.0"
       }
     },
     "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.1"
       }
     },
     "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+      "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
       "dev": true
     },
     "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "release-zalgo": {
@@ -5133,34 +4756,7 @@
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
-        "es6-error": "^4.0.1"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "^1.0.0"
+        "es6-error": "4.1.1"
       }
     },
     "require-directory": {
@@ -5187,23 +4783,32 @@
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "5.0.0"
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "1.0.1"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -5211,9 +4816,15 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
@@ -5221,7 +4832,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.4"
       },
       "dependencies": {
         "glob": {
@@ -5230,12 +4841,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -5246,7 +4857,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-parallel": {
@@ -5261,7 +4872,7 @@
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.10.0"
       }
     },
     "safe-buffer": {
@@ -5288,7 +4899,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "serialize-error": {
@@ -5303,19 +4914,13 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -5331,33 +4936,20 @@
       "dev": true
     },
     "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
-      }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^1.0.0"
+        "ansi-styles": "3.2.0",
+        "astral-regex": "1.0.0",
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "source-map": {
@@ -5367,12 +4959,13 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
-      "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -5389,12 +4982,12 @@
       "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
       "dev": true,
       "requires": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
+        "foreground-child": "1.5.6",
+        "mkdirp": "0.5.1",
+        "os-homedir": "1.0.2",
+        "rimraf": "2.6.3",
+        "signal-exit": "3.0.2",
+        "which": "1.3.0"
       }
     },
     "spdx-correct": {
@@ -5403,7 +4996,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -5425,9 +5018,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
     "standard": {
@@ -5436,15 +5029,15 @@
       "integrity": "sha512-F3Su3IAxDrOW+v4O/WiPFp6SZ0FWj+H4NEtGrEI1iaCf5LWD0nIfcXh0GIyKQgpmswQFWBIAvgONihT8U5UM4w==",
       "dev": true,
       "requires": {
-        "eslint": "~6.4.0",
+        "eslint": "6.4.0",
         "eslint-config-standard": "14.1.0",
         "eslint-config-standard-jsx": "8.1.0",
-        "eslint-plugin-import": "~2.18.0",
-        "eslint-plugin-node": "~10.0.0",
-        "eslint-plugin-promise": "~4.2.1",
-        "eslint-plugin-react": "~7.14.2",
-        "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "^12.0.0"
+        "eslint-plugin-import": "2.18.2",
+        "eslint-plugin-node": "10.0.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-react": "7.14.3",
+        "eslint-plugin-standard": "4.0.1",
+        "standard-engine": "12.0.0"
       }
     },
     "standard-engine": {
@@ -5453,10 +5046,10 @@
       "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
       "dev": true,
       "requires": {
-        "deglob": "^4.0.0",
-        "get-stdin": "^7.0.0",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^3.1.0"
+        "deglob": "4.0.1",
+        "get-stdin": "7.0.0",
+        "minimist": "1.2.0",
+        "pkg-conf": "3.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -5465,7 +5058,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "get-stdin": {
@@ -5486,11 +5079,11 @@
           "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.15",
-            "parse-json": "^4.0.0",
-            "pify": "^4.0.1",
-            "strip-bom": "^3.0.0",
-            "type-fest": "^0.3.0"
+            "graceful-fs": "4.2.2",
+            "parse-json": "4.0.0",
+            "pify": "4.0.1",
+            "strip-bom": "3.0.0",
+            "type-fest": "0.3.1"
           }
         },
         "locate-path": {
@@ -5499,8 +5092,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "minimist": {
@@ -5515,7 +5108,7 @@
           "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -5524,7 +5117,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.1"
           }
         },
         "parse-json": {
@@ -5533,8 +5126,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "pify": {
@@ -5549,8 +5142,8 @@
           "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0",
-            "load-json-file": "^5.2.0"
+            "find-up": "3.0.0",
+            "load-json-file": "5.3.0"
           }
         }
       }
@@ -5561,8 +5154,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string.prototype.trimleft": {
@@ -5571,8 +5164,8 @@
       "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string.prototype.trimright": {
@@ -5581,17 +5174,8 @@
       "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "strip-ansi": {
@@ -5600,7 +5184,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5618,12 +5202,12 @@
       "dev": true
     },
     "strip-bom-buf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
+      "integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.1"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -5633,13 +5217,10 @@
       "dev": true
     },
     "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^4.0.1"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -5653,20 +5234,42 @@
       "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "indent-string": "^3.2.0",
-        "js-yaml": "^3.10.0",
-        "serialize-error": "^2.1.0",
-        "strip-ansi": "^4.0.0"
+        "arrify": "1.0.1",
+        "indent-string": "3.2.0",
+        "js-yaml": "3.13.1",
+        "serialize-error": "2.1.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
       }
     },
     "supports-color": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-      "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.0.0.tgz",
+      "integrity": "sha512-WRt32iTpYEZWYOpcetGm0NPeSvaebccx7hhS/5M6sAiqnhedtFCHFxkjzZlJvFNCPowiKSFGiZk5USQDFy83vQ==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "4.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        }
       }
     },
     "symbol-observable": {
@@ -5681,10 +5284,10 @@
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "6.10.2",
+        "lodash": "4.17.15",
+        "slice-ansi": "2.1.0",
+        "string-width": "3.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5699,9 +5302,9 @@
           "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
+            "ansi-styles": "3.2.0",
+            "astral-regex": "1.0.0",
+            "is-fullwidth-code-point": "2.0.0"
           }
         },
         "string-width": {
@@ -5710,9 +5313,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -5721,7 +5324,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -5732,7 +5335,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "test-exclude": {
@@ -5741,10 +5344,10 @@
       "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
+        "glob": "7.1.4",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "4.0.0",
+        "require-main-filename": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -5753,7 +5356,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "glob": {
@@ -5762,12 +5365,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "load-json-file": {
@@ -5776,10 +5379,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "locate-path": {
@@ -5788,8 +5391,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -5798,7 +5401,7 @@
           "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -5807,7 +5410,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.1"
           }
         },
         "parse-json": {
@@ -5816,8 +5419,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -5826,7 +5429,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -5841,9 +5444,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -5852,8 +5455,8 @@
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "3.0.0",
+            "read-pkg": "3.0.0"
           }
         }
       }
@@ -5870,26 +5473,10 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
-      }
-    },
     "time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
-      "dev": true
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
     "tmp": {
@@ -5898,19 +5485,28 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "7.0.0"
+      }
+    },
     "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
       "dev": true
     },
     "trim-off-newlines": {
@@ -5937,7 +5533,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-fest": {
@@ -5946,6 +5542,15 @@
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "1.0.0"
+      }
+    },
     "uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -5953,8 +5558,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
+        "commander": "2.20.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -5972,6 +5577,34 @@
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
       "dev": true
     },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.5"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "dev": true
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -5984,7 +5617,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unique-temp-dir": {
@@ -5993,32 +5626,29 @@
       "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "os-tmpdir": "^1.0.1",
+        "mkdirp": "0.5.1",
+        "os-tmpdir": "1.0.2",
         "uid2": "0.0.3"
       }
     },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
-    },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "3.2.0",
+        "chalk": "2.3.0",
+        "configstore": "4.0.0",
+        "has-yarn": "2.1.0",
+        "import-lazy": "2.1.0",
+        "is-ci": "2.0.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "3.0.0",
+        "is-yarn-global": "0.3.0",
+        "latest-version": "5.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "uri-js": {
@@ -6027,23 +5657,17 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "2.0.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
     },
     "uuid": {
       "version": "3.3.3",
@@ -6063,14 +5687,23 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "1.0.3"
       }
     },
     "well-known-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-      "integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+      "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true
     },
     "which": {
@@ -6079,7 +5712,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -6089,12 +5722,12 @@
       "dev": true
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "wordwrap": {
@@ -6109,9 +5742,9 @@
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "3.2.0",
+        "string-width": "3.1.0",
+        "strip-ansi": "5.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6126,9 +5759,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -6137,7 +5770,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -6154,56 +5787,19 @@
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
+      "integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "write-json-file": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
-      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-      "dev": true,
-      "requires": {
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "sort-keys": "^2.0.0",
-        "write-file-atomic": "^2.0.0"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-          "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
-    "write-pkg": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
-      "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-      "dev": true,
-      "requires": {
-        "sort-keys": "^2.0.0",
-        "write-json-file": "^2.2.0"
+        "imurmurhash": "0.1.4",
+        "is-typedarray": "1.0.0",
+        "signal-exit": "3.0.2",
+        "typedarray-to-buffer": "3.1.5"
       }
     },
     "xdg-basedir": {
@@ -6236,16 +5832,16 @@
       "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "cliui": "5.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "2.0.5",
+        "require-directory": "2.1.1",
+        "require-main-filename": "2.0.0",
+        "set-blocking": "2.0.0",
+        "string-width": "3.1.0",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "13.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6260,7 +5856,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "locate-path": {
@@ -6269,8 +5865,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -6279,7 +5875,7 @@
           "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -6288,7 +5884,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.2.1"
           }
         },
         "string-width": {
@@ -6297,9 +5893,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -6308,7 +5904,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -6319,8 +5915,8 @@
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.3.1",
+        "decamelize": "1.2.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "ava": "^0.25.0",
+    "ava": "^2.4.0",
     "nyc": "^14.1.1",
     "standard": "^14.3.0"
   },
@@ -16,8 +16,11 @@
     "lint": "standard",
     "docs": "node docs/generate.js",
     "fixtures": "node fixtures/index.js",
-    "test": "ava \"test/spec/**/*.js\" && npm run docs && npm run fixtures",
-    "coverage": "nyc ava \"test/spec/**/*.js\""
+    "test": "ava && npm run docs && npm run fixtures",
+    "coverage": "nyc ava"
+  },
+  "ava": {
+    "files": ["test/spec/**/*.js"]
   },
   "repository": {
     "type": "git",

--- a/test/spec/array.js
+++ b/test/spec/array.js
@@ -53,33 +53,18 @@ test('last returns last element of an array', assert => {
 
 test('sum returns the sum of a list of numbers', assert => {
   assert.deepEqual(array.sum([3, 10, 2]), 15)
-})
-
-test('sum returns the sum of a list of numbers', assert => {
   assert.deepEqual(array.sum([100, 200, 1]), 301)
 })
 
 test('average returns the average of a list of numbers', assert => {
   assert.deepEqual(array.average([100, 200]), 150)
-})
-
-test('average returns the average of a list of numbers', assert => {
   assert.deepEqual(array.average([2, 0]), 1)
 })
 
 test('median returns the median of a list of numbers', assert => {
   assert.deepEqual(array.median([6, 4, 2, 4, 4]), 4)
-})
-
-test('median returns the median of a list of numbers', assert => {
   assert.deepEqual(array.median([1, 2, 3, 5, 5, 6]), 4)
-})
-
-test('median returns the median of a list of numbers', assert => {
   assert.deepEqual(array.median([5, 18, 1]), 5)
-})
-
-test('median returns the median of a list of numbers', assert => {
   assert.deepEqual(array.median([91, 210, 205, 204, 212]), 205)
 })
 
@@ -93,13 +78,7 @@ test('unique returns a copy of the array without duplicate items', assert => {
 
 test('nth gets element at index "n" of array', assert => {
   assert.deepEqual(array.nth([1, 2, 3, 4, 5], 4), 4)
-})
-
-test('nth gets element at index "n" of array', assert => {
   assert.deepEqual(array.nth([1, 2, 3, 4, 5], -2), 4)
-})
-
-test('nth gets element at index "n" of array', assert => {
   assert.deepEqual(array.nth([1, 2, 3, 4, 5], -5), 1)
 })
 
@@ -109,69 +88,33 @@ test('sample returns a random item from array', assert => {
 
 test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate([1, 2, 3]), [1, 2, 3])
-})
-
-test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate([1, 2, 3], 1), [2, 3, 1])
-})
-
-test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate([1, 2, 3], 2), [3, 1, 2])
-})
-
-test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate([1, 2, 3], 3), [1, 2, 3])
-})
-
-test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate([1, 2, 3], 4), [2, 3, 1])
-})
-
-test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate([1, 2, 3], -1), [3, 1, 2])
-})
-
-test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate(['lorem', 'ipsum', 'dolor', 'santo'], -2), ['dolor', 'santo', 'lorem', 'ipsum'])
-})
-
-test('rotate shifts "n" items out of the array and pushes them back on the end', assert => {
   assert.deepEqual(array.rotate([1, 2, 3], -3), [1, 2, 3])
 })
 
 test('drop returns the tail of array after dropping the first `n` elements.', assert => {
   assert.deepEqual(array.drop([1, 2, 3], 2), [3])
-})
-
-test('drop returns the tail of array after dropping the first `n` elements.', assert => {
   assert.deepEqual(array.drop([1, 2, 3, 4, 5, 6], 3), [4, 5, 6])
-})
-
-test('drop returns the tail of array after dropping the first `n` elements.', assert => {
   assert.deepEqual(array.drop('Hello World', 6), 'World')
 })
 
 test('head returns first element of an array', assert => {
   assert.deepEqual(array.head([1, 2, 3, 4, 5, 6]), 1)
-})
-
-test('head returns first element of an array', assert => {
   assert.deepEqual(array.head('Hello World'), 'H')
 })
 
 test('take takes n items of an array.', assert => {
   assert.deepEqual(array.take([1, 2, 3, 4, 5, 6], 2), [1, 2])
-})
-
-test('take takes n items of an array.', assert => {
   assert.deepEqual(array.take('Hello World', 5), 'Hello')
 })
 
 test('slice returns a shallow copy of a portion of an array into a new array object selected from start to end', assert => {
   assert.deepEqual(array.slice([1, 2, 3, 4, 5, 6], 3, 5), [4, 5])
-})
-
-test('slice returns a shallow copy of a portion of an array into a new array object selected from start to end', assert => {
   assert.deepEqual(array.slice('Hello World', 6, 9), 'Wor')
 })
 
@@ -182,18 +125,14 @@ test('pluck extracts a list of all property values', assert => {
       { name: 'larry', age: 50 },
       { name: 'curly', age: 60 }
     ], 'name'), ['moe', 'larry', 'curly'])
-})
 
-test('pluck returns a list of only existing property values', assert => {
   assert.deepEqual(
     array.pluck([
       { foo: 'moe', age: 40 },
       { name: 'larry', age: 50 },
       { bar: 'curly', age: 60 }
     ], 'name'), ['larry'])
-})
 
-test('pluck returns a list of not empty property values', assert => {
   assert.deepEqual(
     array.pluck([
       { name: '', age: 40 },

--- a/test/spec/collection.js
+++ b/test/spec/collection.js
@@ -57,32 +57,18 @@ test('prepend for array should add many arguments at the beginning of the array'
 
 test('size returns length of collection', assert => {
   assert.deepEqual(collection.size([1, 2, 3, 4, 5]), 5)
-})
-
-test('size returns length of collection', assert => {
   assert.deepEqual(collection.size('foobar'), 6)
-})
-
-test('size returns length of collection', assert => {
   assert.deepEqual(collection.size({ a: 1, b: 2 }), 2)
-})
-
-test('size returns length of collection', assert => {
   assert.deepEqual(collection.size(new Set([1, 2, 3, 4, 5])), 5)
 })
 
 test('reverse should reverse collection', t => {
   var parsed = collection.reverse('foo')
   t.deepEqual(parsed, 'oof')
-})
 
-test('reverse should reverse collection', t => {
-  var parsed = collection.reverse('12345')
+  parsed = collection.reverse('12345')
   t.deepEqual(parsed, '54321')
-})
-
-test('reverse should reverse collection', t => {
-  var parsed = collection.reverse([1, 2, 3, 4])
+  parsed = collection.reverse([1, 2, 3, 4])
   t.deepEqual(parsed, [4, 3, 2, 1])
 })
 

--- a/test/spec/date.js
+++ b/test/spec/date.js
@@ -7,17 +7,11 @@ test('isostring returns a valid date', t => {
 
 test('format returns a date in DD-MM-YYYY format by default', t => {
   t.deepEqual(date.format(new Date('2013/06/13')), '13-06-2013')
-})
-
-test('format returns a date in DD-MM-YYYY format by default', t => {
   t.deepEqual(date.format('06-27-13'), '27-06-2013')
 })
 
 test('format returns "Invalid Date" message when passed date is invalid', t => {
   t.deepEqual(date.format(new Date('2018/15/13'), 'DD/MM/YYYY'), 'Invalid Date')
-})
-
-test('format returns "Invalid Date" message when passed date is invalid', t => {
   t.deepEqual(date.format('27-06-2013', 'DD/MM/YYYY'), 'Invalid Date')
 })
 
@@ -25,23 +19,10 @@ test('format returns "Invalid Format" message when format is invalid', t => {
   t.deepEqual(date.format('2013-06-27', 'DD!MM!YYYY'), 'Invalid Format')
 })
 
-test('format returns a date in given format', t => {
-  t.deepEqual(date.format(new Date(2018, 4, 23), 'MM'), '05')
-})
-
 test('format returns number of the month', t => {
   t.deepEqual(date.format(new Date('2018-05-23'), 'MM'), '05')
-})
-
-test('format returns number of the month', t => {
   t.deepEqual(date.format(new Date('2018/05/23'), 'MM'), '05')
-})
-
-test('format returns number of the month', t => {
   t.deepEqual(date.format(new Date('2018-05'), 'MM'), '05')
-})
-
-test('format returns number of the month', t => {
   t.deepEqual(date.format(new Date('2018'), 'MM'), '01')
 })
 
@@ -55,109 +36,50 @@ test('format returns number of the year', t => {
 
 test('format returns a date in given format', t => {
   t.deepEqual(date.format(new Date(2018, 4, 23), 'DD/MM/YYYY'), '23/05/2018')
-})
-
-test('format returns a date in given format', t => {
   t.deepEqual(date.format(new Date(2018, 4, 23), 'MM/DD/YYYY'), '05/23/2018')
-})
-
-test('format returns a date in given format', t => {
   t.deepEqual(date.format(new Date(2018, 4, 23), 'MM.DD.YYYY'), '05.23.2018')
-})
-
-test('format returns a date in given format', t => {
   t.deepEqual(date.format(new Date(2018, 4, 23), 'MM-DD-YYYY'), '05-23-2018')
-})
-
-test('format returns a date in given format', t => {
   t.deepEqual(date.format(new Date(2018, 4, 23), 'YYYY/MM/DD'), '2018/05/23')
-})
-
-test('format returns a date in given format', t => {
   t.deepEqual(date.format(new Date(2018, 4, 23), 'MM YYYY'), '05 2018')
-})
-
-test('format returns a date in given format', t => {
   t.deepEqual(date.format(new Date(2018, 4, 23), 'MM-YYYY'), '05-2018')
+  t.deepEqual(date.format(new Date(2018, 4, 23), 'MM'), '05')
 })
 
 test('day returns the day of the month', t => {
   t.deepEqual(date.day(new Date(2018, 4, 28)), 28)
-})
-
-test('day returns the day of the month', t => {
   t.deepEqual(date.day(new Date(2017, 1, 11)), 11)
-})
-
-test('day returns the day of the month', t => {
   t.deepEqual(date.day('27-06-2013'), 'Invalid Date')
 })
 
 test('weekday returns the day of the week', t => {
   t.deepEqual(date.weekday(new Date(2018, 4, 28)), 1)
-})
-
-test('weekday returns the day of the week', t => {
   t.deepEqual(date.weekday(new Date(2018, 4, 27)), 0)
-})
-
-test('weekday returns the day of the week', t => {
   t.deepEqual(date.weekday(new Date(2017, 1, 11)), 6)
-})
-
-test('weekday returns the day of the week', t => {
   t.deepEqual(date.weekday('27-06-2013'), 'Invalid Date')
 })
 
 test('month returns the number of the month', t => {
   t.deepEqual(date.month(new Date(2018, 4, 28)), 4)
-})
-
-test('month returns the number of the month', t => {
   t.deepEqual(date.month(new Date(2018, 1, 27)), 1)
 })
 
 test('year returns the number of the year', t => {
   t.deepEqual(date.year(new Date(2018, 4, 28)), 2018)
-})
-
-test('year returns the number of the year', t => {
   t.deepEqual(date.year(new Date(1995, 2, 13)), 1995)
 })
 
 test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2043, 9, 25)), 'Sunday, 25th of October 2043')
-})
-
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2018, 5, 15)), 'Friday, 15th of June 2018')
-})
-
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2018, 5, 1)), 'Friday, 1st of June 2018')
-})
-
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2018, 2, 21)), 'Wednesday, 21st of March 2018')
-})
-
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2018, 2, 21), 'pl-Pl'), 'środa, 21 marca 2018')
-})
-
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2018, 5, 21), 'pl-Pl'), 'czwartek, 21 czerwca 2018')
-})
-
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2018, 8, 8), 'pl-Pl'), 'sobota, 8 września 2018')
-})
-
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
   t.deepEqual(date.prettydate(new Date(2018, 11, 30), 'pl-Pl'), 'niedziela, 30 grudnia 2018')
 })
 
-test('prettydate returns date string containing name of the day, number of the day, name of the month and year', t => {
+test('prettydate not supported localization', t => {
   const error = t.throws(() => date.prettydate(new Date(2018, 11, 30), 'de-De'))
   t.is(error.message, 'de-De localization is not supported.')
 })

--- a/test/spec/math.js
+++ b/test/spec/math.js
@@ -176,11 +176,6 @@ test('int parses string and returns integer', t => {
   t.deepEqual(parsed, 4)
 })
 
-test('float parses string and returns float', t => {
-  var parsed = math.float('4.25')
-  t.deepEqual(parsed, 4.25)
-})
-
 test('float works for numbers', t => {
   var parsed = math.float(1)
   t.deepEqual(parsed, 1.00)
@@ -189,106 +184,75 @@ test('float works for numbers', t => {
 test('float parses string and returns float', t => {
   var parsed = math.float('4,25')
   t.deepEqual(parsed, 4.25)
-})
 
-test('float parses string and returns float', t => {
-  var parsed = math.float('100 000,01')
+  parsed = math.float('100 000,01')
   t.deepEqual(parsed, 100000.01)
-})
 
-test('float parses string and returns float', t => {
-  var parsed = math.float('100000.01')
+  parsed = math.float('100000.01')
   t.deepEqual(parsed, 100000.01)
+
+  parsed = math.float('4.25')
+  t.deepEqual(parsed, 4.25)
 })
 
 test('clamp clamps value inside range', t => {
   t.deepEqual(math.clamp(10, 20, 30), 20)
-})
-
-test('clamp clamps value inside range', t => {
   t.deepEqual(math.clamp(20, 20, 30), 20)
-})
-
-test('clamp clamps value inside range', t => {
   t.deepEqual(math.clamp(25, 20, 30), 25)
-})
-
-test('clamp clamps value inside range', t => {
   t.deepEqual(math.clamp(30, 20, 30), 30)
-})
-
-test('clamp clamps value inside range', t => {
   t.deepEqual(math.clamp(31, 20, 30), 30)
 })
 
 test('percentage converts number to percent format', t => {
   t.deepEqual(math.percentage(0.25), '25%')
-})
-
-test('percentage converts number to percent format', t => {
   t.deepEqual(math.percentage(1), '100%')
 })
 
 test('fixed formats a number using fixed-point notation', t => {
   t.deepEqual(math.fixed(25.32), '25')
-})
-
-test('fixed formats a number using fixed-point notation', t => {
   t.deepEqual(math.fixed(25.32, 1), '25.3')
 })
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(100)
+test('monetize formats a number to zloty currency format', t => {
+  var parsed = math.monetize(100)
   t.deepEqual(parsed, '100,00 zł')
-})
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(100.50, { symbol: '€', separator: '.' })
-  t.deepEqual(parsed, '100.50 €')
-})
-
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(1000)
+  parsed = math.monetize(1000)
   t.deepEqual(parsed, '1 000,00 zł')
-})
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(1000000)
+  parsed = math.monetize(1000000)
   t.deepEqual(parsed, '1 000 000,00 zł')
-})
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(531722.07)
+  parsed = math.monetize(531722.07)
   t.deepEqual(parsed, '531 722,07 zł')
-})
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(100230.1)
+  parsed = math.monetize(100230.1)
   t.deepEqual(parsed, '100 230,10 zł')
 })
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(100, {
+test('monetize formats a number to euro currency format', t => {
+  var parsed = math.monetize(100.50, { symbol: '€', separator: '.' })
+  t.deepEqual(parsed, '100.50 €')
+})
+
+test('monetize formats a number to custom currency format', t => {
+  var parsed = math.monetize(100, {
     symbol: '$',
     space: false,
     ending: false,
     separator: '.'
   })
   t.deepEqual(parsed, '$100.00')
-})
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(100.50, {
+  parsed = math.monetize(100.50, {
     digits: 1,
     symbol: '€',
     separator: '.',
     space: false
   })
   t.deepEqual(parsed, '100.5€')
-})
 
-test('monetize formats a number to currency format', t => {
-  const parsed = math.monetize(100.50, {
+  parsed = math.monetize(100.50, {
     digits: 1,
     symbol: '€',
     separator: '.',
@@ -299,47 +263,35 @@ test('monetize formats a number to currency format', t => {
 })
 
 test('cube returns the third power of the number', t => {
-  const parsed = math.cube(5)
+  var parsed = math.cube(5)
   t.deepEqual(parsed, 125)
-})
 
-test('cube returns the third power of the number', t => {
-  const parsed = math.cube(-4)
+  parsed = math.cube(-4)
   t.deepEqual(parsed, -64)
 })
 
 test('inches converts feest to inches', t => {
-  const parsed = math.inches(1)
+  var parsed = math.inches(1)
   t.deepEqual(parsed, 12)
-})
 
-test('inches converts feets to inches', t => {
-  const parsed = math.inches(0.01)
+  parsed = math.inches(0.01)
   t.deepEqual(parsed, 0.12)
-})
 
-test('inches converts feets to inches', t => {
-  const parsed = math.inches(0.01, 2, false)
+  parsed = math.inches(0.01, 2, false)
   t.deepEqual(parsed, '0.12″')
 })
 
 test('inches converts inches to feets', t => {
-  const parsed = math.feet(1)
+  var parsed = math.feet(1)
   t.deepEqual(parsed, 0.08)
-})
 
-test('feet converts inches to feets', t => {
-  const parsed = math.feet(1, 5)
+  parsed = math.feet(1, 5)
   t.deepEqual(parsed, 0.08333)
-})
 
-test('feet converts inches to feets', t => {
-  const parsed = math.feet(60)
+  parsed = math.feet(60)
   t.deepEqual(parsed, 5)
-})
 
-test('feet converts inches to feets', t => {
-  const parsed = math.feet(13.25)
+  parsed = math.feet(13.25)
   t.deepEqual(parsed, 1.10)
 })
 
@@ -349,21 +301,17 @@ test('feet converts f to feets', t => {
 })
 
 test('degrees converts radians to degrees', t => {
-  const parsed = math.degrees(1)
+  var parsed = math.degrees(1)
   t.deepEqual(parsed, 57.3)
-})
 
-test('degrees converts radians to degrees', t => {
-  const parsed = math.degrees(5)
+  parsed = math.degrees(5)
   t.deepEqual(parsed, 286.48)
 })
 
 test('radians converts degrees to radians', t => {
-  const parsed = math.radians(12)
+  var parsed = math.radians(12)
   t.deepEqual(parsed, 0.21)
-})
 
-test('radians converts degrees to radians', t => {
-  const parsed = math.radians(-1, 10)
+  parsed = math.radians(-1, 10)
   t.deepEqual(parsed, -0.0174532925)
 })

--- a/test/spec/object.js
+++ b/test/spec/object.js
@@ -43,22 +43,18 @@ test('pat overrides deeply nested fields', t => {
 })
 
 test('values returns an array containing the values that correspond to all of a given object\'s own enumerable string properties', t => {
-  const parsed = object.values({ foo: 'bar', baz: [1, 2, 3] })
+  var parsed = object.values({ foo: 'bar', baz: [1, 2, 3] })
   t.deepEqual(parsed.length, 2)
-})
 
-test('values returns an array containing the values that correspond to all of a given object\'s own enumerable string properties', t => {
-  const parsed = object.values({})
+  parsed = object.values({})
   t.deepEqual(parsed.length, 0)
 })
 
 test('keys returns an array containing the names of all of the given object\'s own enumerable string properties', t => {
-  const parsed = object.keys({ foo: 'bar', baz: [1, 2, 3] })
+  var parsed = object.keys({ foo: 'bar', baz: [1, 2, 3] })
   t.deepEqual(parsed.length, 2)
-})
 
-test('keys returns an array containing the names of all of the given object\'s own enumerable string properties', t => {
-  const parsed = object.keys({})
+  parsed = object.keys({})
   t.deepEqual(parsed.length, 0)
 })
 

--- a/test/spec/string.js
+++ b/test/spec/string.js
@@ -2,12 +2,10 @@ import test from 'ava'
 import { string } from '../..'
 
 test('whitespacestrip should remove whitespace characters', t => {
-  const parsed = string.whitespacestrip('\t1234 5678\n')
+  var parsed = string.whitespacestrip('\t1234 5678\n')
   t.deepEqual(parsed, '12345678')
-})
 
-test('whitespacestrip should remove whitespace characters', t => {
-  const parsed = string.whitespacestrip('b  ar')
+  parsed = string.whitespacestrip('b  ar')
   t.deepEqual(parsed, 'bar')
 })
 
@@ -16,32 +14,32 @@ test('pad should return the same string if no padding was provided', t => {
   t.deepEqual(parsed, 'hello')
 })
 
-test('pad should add (n) whitespaces if pad is a number', t => {
+test('pad (left) should add (n) whitespaces if pad is a number', t => {
   const parsed = string.pad('hello world', 5)
   t.deepEqual(parsed, '     hello world')
 })
 
-test('pad should add (n) whitespaces if pad is a number', t => {
+test('pad (right) should add (n) whitespaces if pad is a number', t => {
   const parsed = string.pad('hello world', 5, false)
   t.deepEqual(parsed, 'hello world     ')
 })
 
-test('pad should pad the string with given characters', t => {
+test('pad (left) should pad the string with given characters', t => {
   const parsed = string.pad('hello world', '** ')
   t.deepEqual(parsed, '** hello world')
 })
 
-test('pad should pad the string with given characters', t => {
+test('pad (right) should pad the string with given characters', t => {
   const parsed = string.pad('3', '000', false)
   t.deepEqual(parsed, '3000')
 })
 
-test('pad should pad given number with given characters', t => {
+test('pad (left) should pad given number with given characters', t => {
   const parsed = string.pad(42, '---- ')
   t.deepEqual(parsed, '---- 42')
 })
 
-test('pad should pad given number with given characters', t => {
+test('pad (right) should pad given number with given characters', t => {
   const parsed = string.pad(42, ' ----', false)
   t.deepEqual(parsed, '42 ----')
 })
@@ -61,29 +59,20 @@ test('uppercase should convert string to uppercase', t => {
   t.deepEqual(parsed, 'FOO')
 })
 
-test('uppercase should convert string to uppercase', t => {
-  const parsed = string.uppercase('foo')
-  t.deepEqual(parsed, 'FOO')
-})
+test("underscore shouldn't modify the string, lowercase without underscore", t => {
+  var parsed = string.underscore('foo')
+  t.deepEqual(parsed, 'foo')
 
-test("underscore shouldn't modify the string", t => {
-  const parsed = string.underscore('foo')
+  parsed = string.underscore('foobar')
+  t.deepEqual(parsed, 'foobar')
+
+  parsed = string.underscore(' foo')
   t.deepEqual(parsed, 'foo')
 })
 
-test("underscore shouldn't modify the string", t => {
-  const parsed = string.underscore('foobar')
-  t.deepEqual(parsed, 'foobar')
-})
-
-test("underscore shouldn't modify the string", t => {
+test("underscore shouldn't modify the string, lowercase with underscore", t => {
   const parsed = string.underscore('foo_bar')
   t.deepEqual(parsed, 'foo_bar')
-})
-
-test("underscore shouldn't modify the string", t => {
-  const parsed = string.underscore(' foo')
-  t.deepEqual(parsed, 'foo')
 })
 
 test('underscore should convert string to lowerCase', t => {
@@ -91,118 +80,83 @@ test('underscore should convert string to lowerCase', t => {
   t.deepEqual(parsed, 'foo')
 })
 
-test('underscore should convert string to lowerCase', t => {
+test('underscore should convert string to lowerCase and remove esternal space', t => {
   const parsed = string.underscore(' Foo ')
   t.deepEqual(parsed, 'foo')
 })
 
 test('underscore should add underscore between camelCase words', t => {
-  const parsed = string.underscore('fooBar')
+  var parsed = string.underscore('fooBar')
   t.deepEqual(parsed, 'foo_bar')
-})
 
-test('underscore should add underscore between camelCase words', t => {
-  const parsed = string.underscore('fooBarBaz')
+  parsed = string.underscore('fooBarBaz')
   t.deepEqual(parsed, 'foo_bar_baz')
-})
 
-test('underscore should add underscore between camelCase words', t => {
-  const parsed = string.underscore('fooBarBarBar')
+  parsed = string.underscore('fooBarBarBar')
   t.deepEqual(parsed, 'foo_bar_bar_bar')
-})
 
-test('underscore should add underscore between camelCase words', t => {
-  const parsed = string.underscore('fooBarBazBanQux')
+  parsed = string.underscore('fooBarBazBanQux')
   t.deepEqual(parsed, 'foo_bar_baz_ban_qux')
 })
 
 test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo bar')
+  var parsed = string.underscore('foo bar')
   t.deepEqual(parsed, 'foo_bar')
-})
 
-test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo bar baz ban qux')
+  parsed = string.underscore('foo bar baz ban qux')
   t.deepEqual(parsed, 'foo_bar_baz_ban_qux')
 })
 
-test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo     bar baz')
+test('underscore should add underscore between spaced words, even with multiple spaces', t => {
+  var parsed = string.underscore('foo     bar baz')
   t.deepEqual(parsed, 'foo_bar_baz')
-})
 
-test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo     bar baz    qux')
+  parsed = string.underscore('foo     bar baz    qux')
   t.deepEqual(parsed, 'foo_bar_baz_qux')
 })
 
-test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo Bar')
+test('underscore should add underscore between spaced words and string should be converted lowercase', t => {
+  var parsed = string.underscore('foo Bar')
   t.deepEqual(parsed, 'foo_bar')
-})
 
-test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo Bar Baq')
+  parsed = string.underscore('foo Bar Baq')
   t.deepEqual(parsed, 'foo_bar_baq')
-})
 
-test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo Bar      baq')
-  t.deepEqual(parsed, 'foo_bar_baq')
-})
-
-test('underscore should add underscore between spaced words', t => {
-  const parsed = string.underscore('foo Bar      baq')
+  parsed = string.underscore('foo Bar      baq')
   t.deepEqual(parsed, 'foo_bar_baq')
 })
 
 test('underscore should add underscore between CapitalCase words', t => {
-  const parsed = string.underscore('FooBar')
+  var parsed = string.underscore('FooBar')
   t.deepEqual(parsed, 'foo_bar')
-})
 
-test('underscore should add underscore between CapitalCase words', t => {
-  const parsed = string.underscore('FooBarBaz')
+  parsed = string.underscore('FooBarBaz')
   t.deepEqual(parsed, 'foo_bar_baz')
-})
 
-test('underscore should add underscore between CapitalCase words', t => {
-  const parsed = string.underscore('FooBarBazQux')
+  parsed = string.underscore('FooBarBazQux')
   t.deepEqual(parsed, 'foo_bar_baz_qux')
-})
 
-test('underscore should add underscore between CapitalCase words', t => {
-  const parsed = string.underscore('FooBarBazQux')
+  parsed = string.underscore('FooBarBazQux')
   t.deepEqual(parsed, 'foo_bar_baz_qux')
-})
 
-test('underscore should add underscore between CapitalCase words', t => {
-  const parsed = string.underscore('FooBarBazQux bar')
+  parsed = string.underscore('FooBarBazQux bar')
   t.deepEqual(parsed, 'foo_bar_baz_qux_bar')
 })
 
 test('underscore should convert kebab-case to underscoreCase', t => {
-  const parsed = string.underscore('foo-bar')
+  var parsed = string.underscore('foo-bar')
   t.deepEqual(parsed, 'foo_bar')
-})
 
-test('underscore should convert kebab-case to underscoreCase', t => {
-  const parsed = string.underscore('foo-bar-baz')
+  parsed = string.underscore('foo-bar-baz')
   t.deepEqual(parsed, 'foo_bar_baz')
-})
 
-test('underscore should convert kebab-case to underscoreCase', t => {
-  const parsed = string.underscore('foo-BAR-baz')
+  parsed = string.underscore('foo-BAR-baz')
   t.deepEqual(parsed, 'foo_bar_baz')
-})
 
-test('underscore should convert kebab-case to underscoreCase', t => {
-  const parsed = string.underscore('foo-BaR-baz')
+  parsed = string.underscore('foo-BaR-baz')
   t.deepEqual(parsed, 'foo_ba_r_baz')
-})
 
-test('underscore should convert kebab-case to underscoreCase', t => {
-  const parsed = string.underscore('Bar-baz-baN')
+  parsed = string.underscore('Bar-baz-baN')
   t.deepEqual(parsed, 'bar_baz_ba_n')
 })
 
@@ -211,27 +165,27 @@ test('underscore should convert string containing numbers to underscoreCase', t 
   t.deepEqual(parsed, 'foo_11')
 })
 
-test('underscore should convert string containing numbers to underscoreCase', t => {
+test('underscore should convert string containing numbers to underscoreCase, even with letters between numbers', t => {
   const parsed = string.underscore('foo1o11')
   t.deepEqual(parsed, 'foo_1_o_11')
 })
 
-test('underscore should convert string containing numbers to underscoreCase', t => {
+test('underscore should convert string containing numbers to underscoreCase, even with underscore', t => {
   const parsed = string.underscore('fo_o1o11')
   t.deepEqual(parsed, 'fo_o_1_o_11')
 })
 
-test('underscore should convert string containing numbers to underscoreCase', t => {
+test('underscore should convert string containing numbers to underscoreCase, even starting with number', t => {
   const parsed = string.underscore('1bar')
   t.deepEqual(parsed, '1_bar')
 })
 
-test('underscore should convert string containing numbers to underscoreCase', t => {
+test('underscore should convert string containing numbers to underscoreCase, even if mixed with kebabcase', t => {
   const parsed = string.underscore('1barBan-baz')
   t.deepEqual(parsed, '1_bar_ban_baz')
 })
 
-test('underscore should convert string containing numbers to underscoreCase', t => {
+test('underscore should convert string containing numbers to underscoreCase, but not if are only numbers', t => {
   const parsed = string.underscore('00')
   t.deepEqual(parsed, '00')
 })
@@ -241,11 +195,11 @@ test('capitalize should capitalize first character of string', t => {
   t.deepEqual(parsed, 'Foo')
 })
 
-test('capitalize should capitalize first character of string', t => {
+test('capitalize should capitalize first character of string, even with space in it', t => {
   const parsed = string.capitalize('foo bar and baz')
   t.deepEqual(parsed, 'Foo bar and baz')
 })
-
+/// ////////YOU ARE HERE
 test('lowerCase should convert each character to lowerCase', t => {
   const parsed = string.lowercase('Foo BAR and baZ')
   t.deepEqual(parsed, 'foo bar and baz')
@@ -257,12 +211,10 @@ test('humanize should capitalize first word', t => {
 })
 
 test('humanize should capitalize first word and replace underscores to spaces', t => {
-  const parsed = string.humanize('foo_bar')
+  var parsed = string.humanize('foo_bar')
   t.deepEqual(parsed, 'Foo bar')
-})
 
-test('humanize should capitalize first word and replace underscores to spaces', t => {
-  const parsed = string.humanize('foo_bar. Baz qux _and_qux')
+  parsed = string.humanize('foo_bar. Baz qux _and_qux')
   t.deepEqual(parsed, 'Foo bar. Baz qux  and qux')
 })
 
@@ -272,22 +224,18 @@ test("humanize shouldn't capitalize first word and should replace underscores to
 })
 
 test('titleize should capitalize all the words', t => {
-  const parsed = string.titleize('foo bar')
+  var parsed = string.titleize('foo bar')
   t.deepEqual(parsed, 'Foo Bar')
-})
 
-test('titleize should capitalize all the words', t => {
-  const parsed = string.titleize('foo, bar, baz and qux')
+  parsed = string.titleize('foo, bar, baz and qux')
   t.deepEqual(parsed, 'Foo, Bar, Baz And Qux')
 })
 
 test('dasherize replaces underscores with dashes in the string', t => {
-  const parsed = string.dasherize('foo_bar')
+  var parsed = string.dasherize('foo_bar')
   t.deepEqual(parsed, 'foo-bar')
-})
 
-test('dasherize replaces underscores with dashes in the string', t => {
-  const parsed = string.dasherize('foo_bar__baz')
+  parsed = string.dasherize('foo_bar__baz')
   t.deepEqual(parsed, 'foo-bar--baz')
 })
 
@@ -296,348 +244,273 @@ test('classify creates a class name from a plural', t => {
   t.deepEqual(parsed, 'Foo')
 })
 
-test('classify creates a class name from a plural', t => {
+test('classify creates a class name from a plural in camelcase', t => {
   const parsed = string.classify('fooBars')
   t.deepEqual(parsed, 'FooBar')
 })
 
-test('classify creates a class name from a plural', t => {
+test('classify creates a class name from a singular', t => {
   const parsed = string.classify('fooBar')
   t.deepEqual(parsed, 'FooBar')
 })
 
 test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('car')
+  var parsed = string.pluralize('car')
   t.deepEqual(parsed, 'cars')
+
+  parsed = string.pluralize('bridge')
+  t.deepEqual(parsed, 'bridges')
+
+  parsed = string.pluralize('prize')
+  t.deepEqual(parsed, 'prizes')
+
+  parsed = string.pluralize('toy')
+  t.deepEqual(parsed, 'toys')
+
+  parsed = string.pluralize('ad')
+  t.deepEqual(parsed, 'ads')
 })
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('dress')
+test('pluralize returns the plural form of the word (that ends in "s") in the string', t => {
+  var parsed = string.pluralize('dress')
   t.deepEqual(parsed, 'dresses')
+
+  parsed = string.pluralize('bus')
+  t.deepEqual(parsed, 'buses')
 })
 
-test('pluralize returns the plural form of the word in the string', t => {
+test('pluralize returns the plural form of the word (that ends in "x") in the string', t => {
   const parsed = string.pluralize('box')
   t.deepEqual(parsed, 'boxes')
 })
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('bush')
+test('pluralize returns the plural form of the word (that ends in "h") in the string', t => {
+  var parsed = string.pluralize('bush')
   t.deepEqual(parsed, 'bushes')
-})
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('bus')
-  t.deepEqual(parsed, 'buses')
-})
-
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('watch')
+  parsed = string.pluralize('watch')
   t.deepEqual(parsed, 'watches')
 })
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('bridge')
-  t.deepEqual(parsed, 'bridges')
-})
-
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('prize')
-  t.deepEqual(parsed, 'prizes')
-})
-
-test('pluralize returns the plural form of the word in the string', t => {
+test('pluralize returns the plural form of the word (that ends in "o") in the string', t => {
   const parsed = string.pluralize('tomato')
   t.deepEqual(parsed, 'tomatoes')
 })
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('wife')
+test('pluralize returns the irregolar plural form of the word in the string', t => {
+  var parsed = string.pluralize('wife')
   t.deepEqual(parsed, 'wives')
-})
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('shelf')
+  parsed = string.pluralize('shelf')
   t.deepEqual(parsed, 'shelves')
-})
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('lady')
+  parsed = string.pluralize('lady')
   t.deepEqual(parsed, 'ladies')
-})
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('city')
+  parsed = string.pluralize('city')
   t.deepEqual(parsed, 'cities')
 })
 
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('toy')
-  t.deepEqual(parsed, 'toys')
-})
-
-test('pluralize returns the plural form of the word in the string', t => {
-  const parsed = string.pluralize('ad')
-  t.deepEqual(parsed, 'ads')
-})
-
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('cars')
-  t.deepEqual(parsed, 'car')
-})
-
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('cars')
-  t.deepEqual(parsed, 'car')
-})
-
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('dresses')
+test('singularize returns singular form of a word  (in "es") in the string', t => {
+  var parsed = string.singularize('dresses')
   t.deepEqual(parsed, 'dress')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('boxes')
+  parsed = string.singularize('boxes')
   t.deepEqual(parsed, 'box')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('bushes')
+  parsed = string.singularize('bushes')
   t.deepEqual(parsed, 'bush')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('buses')
+  parsed = string.singularize('buses')
   t.deepEqual(parsed, 'bus')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('watches')
+  parsed = string.singularize('watches')
   t.deepEqual(parsed, 'watch')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('bridges', 'e')
+  parsed = string.singularize('bridges', 'e')
   t.deepEqual(parsed, 'bridge')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('prizes', 'e')
+  parsed = string.singularize('prizes', 'e')
   t.deepEqual(parsed, 'prize')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('tomatoes')
+  parsed = string.singularize('tomatoes')
   t.deepEqual(parsed, 'tomato')
 })
 
 test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('wives')
+  var parsed = string.singularize('toys')
+  t.deepEqual(parsed, 'toy')
+
+  parsed = string.singularize('ads')
+  t.deepEqual(parsed, 'ad')
+
+  parsed = string.singularize('cars')
+  t.deepEqual(parsed, 'car')
+
+  parsed = string.singularize('cars')
+  t.deepEqual(parsed, 'car')
+})
+
+test('singularize returns singular form of a irregolar plural a word in the string', t => {
+  var parsed = string.singularize('wives')
   t.deepEqual(parsed, 'wife')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('shelves', 'f')
+  parsed = string.singularize('shelves', 'f')
   t.deepEqual(parsed, 'shelf')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('thieves', 'f')
+  parsed = string.singularize('thieves', 'f')
   t.deepEqual(parsed, 'thief')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('cities')
+  parsed = string.singularize('cities')
   t.deepEqual(parsed, 'city')
-})
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('ladies')
+  parsed = string.singularize('ladies')
   t.deepEqual(parsed, 'lady')
 })
 
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('toys')
-  t.deepEqual(parsed, 'toy')
-})
-
-test('singularize returns singular form of a word in the string', t => {
-  const parsed = string.singularize('ads')
-  t.deepEqual(parsed, 'ad')
-})
-
-test('swapcase converts uppercase to lowercase and lowercase to uppercase', t => {
+test('swapcase converts lowercase to uppercase', t => {
   const parsed = string.swapcase('foo')
   t.deepEqual(parsed, 'FOO')
 })
 
-test('swapcase converts uppercase to lowercase and lowercase to uppercase', t => {
+test('swapcase converts uppercase to lowercase ', t => {
   const parsed = string.swapcase('FOO')
   t.deepEqual(parsed, 'foo')
 })
 
 test('swapcase converts uppercase to lowercase and lowercase to uppercase', t => {
-  const parsed = string.swapcase('fOo Bar BAZ')
+  var parsed = string.swapcase('fOo Bar BAZ')
+  t.deepEqual(parsed, 'FoO bAR baz')
+
+  parsed = string.swapcase('fOo Bar BAZ')
   t.deepEqual(parsed, 'FoO bAR baz')
 })
 
-test('swapcase converts uppercase to lowercase and lowercase to uppercase', t => {
-  const parsed = string.swapcase('fOo Bar BAZ')
-  t.deepEqual(parsed, 'FoO bAR baz')
-})
-
-test("camelize shouldn't modify the string", t => {
-  const parsed = string.camelize('foo')
+test("camelize shouldn't modify the string in lowercase", t => {
+  var parsed = string.camelize('foo')
   t.deepEqual(parsed, 'foo')
-})
 
-test("camelize shouldn't modify the string", t => {
-  const parsed = string.camelize('foobar')
+  parsed = string.camelize('foobar')
   t.deepEqual(parsed, 'foobar')
 })
 
-test("camelize shouldn't modify the string", t => {
+test("camelize shouldn't modify the string already in camelcase", t => {
   const parsed = string.camelize('fooBar')
   t.deepEqual(parsed, 'fooBar')
 })
 
-test("camelize shouldn't modify the string", t => {
+test('camelize should trim the string', t => {
   const parsed = string.camelize(' foo')
   t.deepEqual(parsed, 'foo')
 })
 
 test('camelize should modify the string to lowerCamelCase by default', t => {
-  const parsed = string.camelize('foo_bar')
+  var parsed = string.camelize('FooBar')
   t.deepEqual(parsed, 'fooBar')
-})
 
-test('camelize should modify the string to lowerCamelCase by default', t => {
-  const parsed = string.camelize('FooBar')
-  t.deepEqual(parsed, 'fooBar')
-})
-
-test('camelize should modify the string to lowerCamelCase by default', t => {
-  const parsed = string.camelize('FooBarbazBan')
+  parsed = string.camelize('FooBarbazBan')
   t.deepEqual(parsed, 'fooBarbazBan')
-})
 
-test('camelize should modify the string to lowerCamelCase by default', t => {
-  const parsed = string.camelize('Foo')
+  parsed = string.camelize('Foo')
   t.deepEqual(parsed, 'foo')
 })
 
-test('camelize should modify the string to lowerCamelCase by default', t => {
-  const parsed = string.camelize('foo_bar_baz_ban_qux')
+test('camelize should modify the string (with underscore) to lowerCamelCase by default', t => {
+  var parsed = string.camelize('foo_bar')
+  t.deepEqual(parsed, 'fooBar')
+
+  parsed = string.camelize('foo_bar_baz_ban_qux')
   t.deepEqual(parsed, 'fooBarBazBanQux')
 })
 
-test('camelize should modify the string to lowerCamelCase by default', t => {
+test('camelize should modify the string (with "-") to lowerCamelCase by default', t => {
   const parsed = string.camelize('foo-Bar')
   t.deepEqual(parsed, 'fooBar')
 })
 
-test('camelize should modify the string to lowerCamelCase by default', t => {
+test('camelize should modify the string (with space) to lowerCamelCase by default', t => {
   const parsed = string.camelize('foo bar')
   t.deepEqual(parsed, 'fooBar')
 })
 
-test('camelize should modify the string to lowerCamelCase by default', t => {
+test('camelize should modify the string (with spaces) to lowerCamelCase by default', t => {
   const parsed = string.camelize('Foo bar ban')
   t.deepEqual(parsed, 'fooBarBan')
 })
 
 test('camelize should modify the string to UpperCamelCase if proper flag has been passed', t => {
-  const parsed = string.camelize('foo', true)
+  var parsed = string.camelize('foo', true)
   t.deepEqual(parsed, 'Foo')
-})
 
-test('camelize should modify the string to UpperCamelCase if proper flag has been passed', t => {
-  const parsed = string.camelize('foobar', true)
+  parsed = string.camelize('foobar', true)
   t.deepEqual(parsed, 'Foobar')
-})
 
-test('camelize should modify the string to UpperCamelCase if proper flag has been passed', t => {
-  const parsed = string.camelize('fooBar', true)
+  parsed = string.camelize('fooBar', true)
   t.deepEqual(parsed, 'FooBar')
 })
 
-test('camelize should modify the string to UpperCamelCase if proper flag has been passed', t => {
-  const parsed = string.camelize(' foo', true)
+test('camelize should modify the string to UpperCamelCase, removing spaces, if proper flag has been passed', t => {
+  var parsed = string.camelize(' foo', true)
   t.deepEqual(parsed, 'Foo')
-})
 
-test('camelize should modify the string to UpperCamelCase if proper flag has been passed', t => {
-  const parsed = string.camelize('Foo_bar', true)
-  t.deepEqual(parsed, 'FooBar')
-})
-
-test('camelize should modify the string to UpperCamelCase if proper flag has been passed', t => {
-  const parsed = string.camelize('foo_bar_baz_ban_qux', true)
-  t.deepEqual(parsed, 'FooBarBazBanQux')
-})
-
-test('camelize should modify the string to UpperCamelCase if proper flag has been passed', t => {
-  const parsed = string.camelize('Foo bar ban', true)
+  parsed = string.camelize('Foo bar ban', true)
   t.deepEqual(parsed, 'FooBarBan')
 })
 
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
-  const parsed = string.constantize('foo')
-  t.deepEqual(parsed, 'FOO')
+test('camelize should modify the string to UpperCamelCase, removing underscore, if proper flag has been passed', t => {
+  var parsed = string.camelize('Foo_bar', true)
+  t.deepEqual(parsed, 'FooBar')
+  parsed = string.camelize('foo_bar_baz_ban_qux', true)
+  t.deepEqual(parsed, 'FooBarBazBanQux')
 })
 
 test('constantize should modify the string to the string in CONST_CONVENTION', t => {
-  const parsed = string.constantize('foobar')
+  var parsed = string.constantize('foo')
+  t.deepEqual(parsed, 'FOO')
+
+  parsed = string.constantize('foobar')
   t.deepEqual(parsed, 'FOOBAR')
 })
 
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
-  const parsed = string.constantize('fooBar')
+test('constantize should modify the camelcase string to the string in CONST_CONVENTION', t => {
+  var parsed = string.constantize('fooBar')
+  t.deepEqual(parsed, 'FOO_BAR')
+
+  parsed = string.constantize('FooBarBazQux')
+  t.deepEqual(parsed, 'FOO_BAR_BAZ_QUX')
+
+  parsed = string.constantize('FooBar')
   t.deepEqual(parsed, 'FOO_BAR')
 })
 
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
-  const parsed = string.constantize('foo_bar')
+test('constantize should modify the snakecase string to the string in CONST_CONVENTION', t => {
+  var parsed = string.constantize('foo_bar')
+  t.deepEqual(parsed, 'FOO_BAR')
+
+  parsed = string.constantize('Foo_Bar')
   t.deepEqual(parsed, 'FOO_BAR')
 })
 
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
-  const parsed = string.constantize('Foo_Bar')
-  t.deepEqual(parsed, 'FOO_BAR')
-})
-
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
-  const parsed = string.constantize('FooBar')
-  t.deepEqual(parsed, 'FOO_BAR')
-})
-
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
+test('constantize should modify the kebabcase string to the string in CONST_CONVENTION', t => {
   const parsed = string.constantize('foo-bar')
   t.deepEqual(parsed, 'FOO_BAR')
 })
 
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
+test('constantize should modify the mixedcase string to the string in CONST_CONVENTION', t => {
   const parsed = string.constantize('foo-bar_baz')
   t.deepEqual(parsed, 'FOO_BAR_BAZ')
 })
 
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
-  const parsed = string.constantize('FooBarBazQux')
-  t.deepEqual(parsed, 'FOO_BAR_BAZ_QUX')
-})
-
-test('constantize should modify the string to the string in CONST_CONVENTION', t => {
+test('constantize should modify the string to the string in CONST_CONVENTION, removing duplicate spaces', t => {
   const parsed = string.constantize('foo   bar')
   t.deepEqual(parsed, 'FOO_BAR')
 })
 
 test("truncate should truncate the string if it's longer than the given maximum string length", t => {
-  const parsed = string.truncate('Once upon a time in a world far far away')
+  var parsed = string.truncate('Once upon a time in a world far far away')
   t.deepEqual(parsed, 'Once upon a time in a world...')
-})
 
-test("truncate should truncate the string if it's longer than the given maximum string length", t => {
-  const parsed = string.truncate('Once upon a time in a world far far away', 17)
+  parsed = string.truncate('Once upon a time in a world far far away', 17)
   t.deepEqual(parsed, 'Once upon a ti...')
 })
 
@@ -651,18 +524,16 @@ test('lowerfirst should lowercase first character of string', t => {
   t.deepEqual(parsed, 'foo')
 })
 
-test('lowerfirst should lowercase first character of string', t => {
+test('lowerfirst should lowercase first character of string even with spaces', t => {
   const parsed = string.lowerfirst('Foo bar baz')
   t.deepEqual(parsed, 'foo bar baz')
 })
 
 test('unescape should convert the HTML entities in string to their corresponding characters', t => {
-  const parsed = string.unescape('&amp;')
+  var parsed = string.unescape('&amp;')
   t.deepEqual(parsed, '&')
-})
 
-test('unescape should convert the HTML entities in string to their corresponding characters', t => {
-  const parsed = string.unescape('&lt;script&gt;alert("foo")&lt;/script&gt;')
+  parsed = string.unescape('&lt;script&gt;alert("foo")&lt;/script&gt;')
   t.deepEqual(parsed, '<script>alert("foo")</script>')
 })
 
@@ -681,52 +552,52 @@ test('quote return a string inside quotes', t => {
   t.deepEqual(parsed, '"foo bar baz"')
 })
 
-test('quote return a string inside quotes', t => {
+test('quote return a string inside quotes, with english localization', t => {
   const parsed = string.quote('foo bar baz', 'en')
   t.deepEqual(parsed, '"foo bar baz"')
 })
 
-test('quote return a string inside quotes', t => {
+test('quote return a string inside quotes, with polish localization', t => {
   const parsed = string.quote('foo bar baz', 'pl')
   t.deepEqual(parsed, '„foo bar baz”')
 })
 
-test('unquote removes quotes from string', t => {
+test('unquote removes left and right quotation mark from string', t => {
   const parsed = string.unquote('„foo bar baz”')
   t.deepEqual(parsed, 'foo bar baz')
 })
 
-test('unquote removes quotes from string', t => {
+test('unquote removes quotation from string', t => {
   const parsed = string.unquote('"foo bar baz"')
   t.deepEqual(parsed, 'foo bar baz')
 })
 
-test('squeeze return a string with removed double characters', t => {
+test('squeeze return a string with removed double characters at the end of the string', t => {
   const parsed = string.squeeze('foo')
   t.deepEqual(parsed, 'fo')
 })
 
-test('squeeze return a string with removed double characters', t => {
+test('squeeze return a string with removed double characters in the middle of the string', t => {
   const parsed = string.squeeze('yellow moon')
   t.deepEqual(parsed, 'yelow mon')
 })
 
-test('squeeze return a string with removed double characters', t => {
+test('squeeze return a string with removed double characters even spaces', t => {
   const parsed = string.squeeze('fooo    bar')
   t.deepEqual(parsed, 'fo bar')
 })
 
-test('squeeze return a string with removed double characters', t => {
+test('squeeze return a string with removed multiple double characters int the middle of the string', t => {
   const parsed = string.squeeze('putters shoot balls')
   t.deepEqual(parsed, 'puters shot bals')
 })
 
-test('squeeze return a string with removed double characters', t => {
+test('squeeze return a string with removed double characters with supplied char', t => {
   const parsed = string.squeeze('yellow moon', 'o')
   t.deepEqual(parsed, 'yellow mon')
 })
 
-test('squeeze return a string with removed double characters', t => {
+test('squeeze return a string with removed double characters with supplied range', t => {
   const parsed = string.squeeze('putters shoot balls', 'm-z')
   t.deepEqual(parsed, 'puters shot balls')
 })
@@ -755,13 +626,11 @@ test('wrap, insert string between passed character', t => {
   t.deepEqual(parsed, '"foo bar baz ban"')
 })
 
-test('wrap, insert string between passed character', t => {
-  const parsed = string.wrap('foo bar baz', '„', '”')
+test('wrap, insert string between passed characters', t => {
+  var parsed = string.wrap('foo bar baz', '„', '”')
   t.deepEqual(parsed, '„foo bar baz”')
-})
 
-test('wrap, insert string between passed character', t => {
-  const parsed = string.wrap('foo bar baz', '(', ')')
+  parsed = string.wrap('foo bar baz', '(', ')')
   t.deepEqual(parsed, '(foo bar baz)')
 })
 
@@ -770,13 +639,11 @@ test('unwrap, removed starting and ending character', t => {
   t.deepEqual(parsed, 'foo bar baz ban')
 })
 
-test('unwrap, removed starting and ending character', t => {
-  const parsed = string.unwrap('„foo bar baz”', '„', '”')
+test('unwrap, removed starting and ending characters', t => {
+  var parsed = string.unwrap('„foo bar baz”', '„', '”')
   t.deepEqual(parsed, 'foo bar baz')
-})
 
-test('unwrap, removed starting and ending character', t => {
-  const parsed = string.unwrap('(foo bar baz)', '(', ')')
+  parsed = string.unwrap('(foo bar baz)', '(', ')')
   t.deepEqual(parsed, 'foo bar baz')
 })
 
@@ -790,12 +657,12 @@ test('strip should remove from string passed string', t => {
   t.deepEqual(parsed, 'foo bar ban')
 })
 
-test('strip should remove from string passed string', t => {
+test('strip should remove from string passed string with length 1 ', t => {
   const parsed = string.strip('foo bar', 'o')
   t.deepEqual(parsed, 'f bar')
 })
 
-test('strip should remove from string passed string', t => {
+test('strip should remove from string passed strings', t => {
   const parsed = string.strip('foo bar baz ban', ['o', 'r', 'a'])
   t.deepEqual(parsed, 'f b bz bn')
 })
@@ -805,7 +672,7 @@ test('replace should replace string characters with newString', t => {
   t.deepEqual(parsed, 'foo bar qux ban')
 })
 
-test('index returns the index of the first occurence of the given substring', t => {
+test('index returns the index of the first occurence of the given substring of length 1', t => {
   const parsed = string.index('hello', 'e')
   t.deepEqual(parsed, 1)
 })
@@ -815,27 +682,27 @@ test('index returns the index of the first occurence of the given substring', t 
   t.deepEqual(parsed, 3)
 })
 
-test('index returns the index of the first occurence of the given substring', t => {
+test('index returns -1 if there is not a occurence of the given substring', t => {
   const parsed = string.index('hello', 'x')
   t.deepEqual(parsed, -1)
 })
 
-test('chop returns string with the last character removed', t => {
+test('chop returns string with the last character removed or a empty string if input is empty', t => {
   const parsed = string.chop('')
   t.deepEqual(parsed, '')
 })
 
-test('chop returns string with the last character removed', t => {
+test('chop returns string with the last character removed, with w32 newline', t => {
   const parsed = string.chop('foo bar baz ban\r\n')
   t.deepEqual(parsed, 'foo bar baz ban')
 })
 
-test('chop returns string with the last character removed', t => {
+test('chop returns string with the last character removed, with a white char', t => {
   const parsed = string.chop('foo bar baz ban\n\r')
   t.deepEqual(parsed, 'foo bar baz ban\n')
 })
 
-test('chop returns string with the last character removed', t => {
+test('chop returns string with the last character removed, with newline', t => {
   const parsed = string.chop('foo bar baz ban\n')
   t.deepEqual(parsed, 'foo bar baz ban')
 })
@@ -846,91 +713,72 @@ test('chop returns string with the last character removed', t => {
 })
 
 test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('foo bar')
-  t.deepEqual(parsed, 'foo bar')
-})
-
-test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('')
-  t.deepEqual(parsed, '')
-})
-
-test('chomp returns string with the given record separator removed from the end of string', t => {
   const parsed = string.chomp('foo bar', 'ar')
   t.deepEqual(parsed, 'foo b')
 })
 
-test('chomp returns string with the given record separator removed from the end of string', t => {
+test('chomp returns string with the given record separator removed from the end of string if at the end of the string', t => {
   const parsed = string.chomp('foo bar', 'qux')
   t.deepEqual(parsed, 'foo bar')
 })
 
-test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('foo bar baz ban\r\n')
-  t.deepEqual(parsed, 'foo bar baz ban')
-})
-
-test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('foo bar baz ban\n\r')
+test('chomp returns string with the default record separator removed from the end of string', t => {
+  var parsed = string.chomp('foo bar baz ban\n\r')
   t.deepEqual(parsed, 'foo bar baz ban\n')
-})
 
-test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('foo bar baz ban\n\r')
+  parsed = string.chomp('foo bar baz ban\n\r')
   t.deepEqual(parsed, 'foo bar baz ban\n')
-})
 
-test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('foo bar baz ban\n')
+  parsed = string.chomp('foo bar baz ban\n')
   t.deepEqual(parsed, 'foo bar baz ban')
-})
 
-test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('foo bar baz ban\r')
+  parsed = string.chomp('foo bar baz ban\r')
   t.deepEqual(parsed, 'foo bar baz ban')
-})
 
-test('chomp returns string with the given record separator removed from the end of string', t => {
-  const parsed = string.chomp('foo\r\n\r\r\n')
+  parsed = string.chomp('foo\r\n\r\r\n')
   t.deepEqual(parsed, 'foo\r\n\r')
+
+  parsed = string.chomp('foo bar')
+  t.deepEqual(parsed, 'foo bar')
+
+  parsed = string.chomp('')
+  t.deepEqual(parsed, '')
+
+  parsed = string.chomp('foo bar baz ban\r\n')
+  t.deepEqual(parsed, 'foo bar baz ban')
 })
 
 test('dot returns string with "." at the end of the string', t => {
-  const parsed = string.dot('')
+  var parsed = string.dot('')
   t.deepEqual(parsed, '.')
-})
-
-test('dot returns string with "." at the end of the string', t => {
-  const parsed = string.dot('foo bar')
+  parsed = string.dot('foo bar')
   t.deepEqual(parsed, 'foo bar.')
 })
 
-test('dot returns string with "." at the end of the string', t => {
+test('dot returns the same string if it ends with a "."', t => {
   const parsed = string.dot('foo bar.')
   t.deepEqual(parsed, 'foo bar.')
 })
 
-test('crop truncates string at full words', t => {
+test('crop don\'t truncates string at full words if string is shorter', t => {
   const parsed = string.crop('foo bar baz ban bar', 100)
   t.deepEqual(parsed, 'foo bar baz ban bar')
 })
 
 test('crop truncates string at full words', t => {
-  const parsed = string.crop('foo bar baz ban bar', 10)
+  var parsed = string.crop('foo bar baz ban bar', 10)
   t.deepEqual(parsed, 'foo bar...')
-})
 
-test('crop truncates string at full words', t => {
-  const parsed = string.crop('consectetur adipiscing elit. Suspendisse venenatis ultrices arcu ut fermentum', 70)
+  parsed = string.crop('consectetur adipiscing elit. Suspendisse venenatis ultrices arcu ut fermentum', 70)
   t.deepEqual(parsed, 'consectetur adipiscing elit. Suspendisse venenatis ultrices arcu ut...')
 })
 
-test('hyphenate replaces spaces with hyphens, split camelCase text, remove non-word chars and convert to lower case', t => {
+test('hyphenate replaces spaces with hyphens and remove non-word chars', t => {
   const parsed = string.hyphenate('%# lorem ipsum  ? $  dolor')
   t.deepEqual(parsed, 'lorem-ipsum-dolor')
 })
 
-test('hyphenate replaces spaces with hyphens, split camelCase text, remove non-word chars and convert to lower case', t => {
+test('hyphenate replaces spaces with hyphens, split camelCase text and convert to lower case', t => {
   const parsed = string.hyphenate('loremIpsum')
   t.deepEqual(parsed, 'lorem-ipsum')
 })
@@ -940,7 +788,7 @@ test('slugify convert to lower case, remove non-word chars and replace spaces wi
   t.deepEqual(parsed, 'loremipsum-dolor-special-chars')
 })
 
-test('slugify convert to lower case, remove non-word chars and replace spaces with the delimeter', t => {
+test('slugify convert to lower case, remove non-word chars and replace spaces with the supplied delimeter', t => {
   const parsed = string.slugify('loremIpsum dolor special chars', '_')
   t.deepEqual(parsed, 'loremipsum_dolor_special_chars')
 })
@@ -950,27 +798,27 @@ test('initials converts string to initials', t => {
   t.deepEqual(parsed, 'FB')
 })
 
-test('initials converts string to initials', t => {
+test('initials converts string to initials joined by supplied string', t => {
   const parsed = string.initials('Foo Bar', ('.'))
   t.deepEqual(parsed, 'F.B')
 })
 
-test('initials converts string to initials', t => {
+test('initials converts string to initials joined by supplied string. "-" act as space', t => {
   const parsed = string.initials('Foo Barin-Bar', ('.'))
   t.deepEqual(parsed, 'F.B.B')
 })
 
-test('initials converts string to initials', t => {
+test('initials converts strings to initials', t => {
   const parsed = string.initials(['foo bar', 'ban bar'], '.')
   t.deepEqual(parsed, ['F.B', 'B.B'])
 })
 
-test('htmlstrip returns text content of html tags', t => {
+test('htmlstrip returns text content of html tag', t => {
   const parsed = string.htmlstrip('<div>foo</div>')
   t.deepEqual(parsed, 'foo')
 })
 
-test('htmlstrip returns text content of html tags', t => {
+test('htmlstrip returns text content of html tag inside another', t => {
   const parsed = string.htmlstrip('<div><div>foo</div></div>')
   t.deepEqual(parsed, 'foo')
 })
@@ -980,142 +828,121 @@ test('htmlstrip returns text content of html tags', t => {
   t.deepEqual(parsed, 'foofoo')
 })
 
-test('htmlstrip returns text content of html tags', t => {
+test('htmlstrip returns text content of html tag and text outside tag', t => {
   const parsed = string.htmlstrip('Hello <b><i>world!</i></b>')
   t.deepEqual(parsed, 'Hello world!')
 })
 
-test('htmlstrip returns text content of html tags', t => {
-  const parsed = string.htmlstrip('<a href="">lorem <strong>ipsum</strong></a>')
+test('htmlstrip returns text content of html tags, ingnoring attributes', t => {
+  var parsed = string.htmlstrip('<a href="">lorem <strong>ipsum</strong></a>')
   t.deepEqual(parsed, 'lorem ipsum')
-})
 
-test('htmlstrip returns text content of html tags', t => {
-  const parsed = string.htmlstrip('<article attr="foo \'bar\'">lorem</article> ipsum')
+  parsed = string.htmlstrip('<article attr="foo \'bar\'">lorem</article> ipsum')
   t.deepEqual(parsed, 'lorem ipsum')
-})
 
-test('htmlstrip returns text content of html tags', t => {
-  const parsed = string.htmlstrip('<a href="https://example.com">lorem ipsum</a>')
+  parsed = string.htmlstrip('<a href="https://example.com">lorem ipsum</a>')
   t.deepEqual(parsed, 'lorem ipsum')
 })
 
 test('split should return an array', t => {
-  const result = string.split('foo,bar,bazz', ',')
+  var result = string.split('foo,bar,bazz', ',')
   t.deepEqual(result, ['foo', 'bar', 'bazz'])
-})
 
-test('split should return an array', t => {
-  const result = string.split('foo bar baz')
+  result = string.split('foo bar baz')
   t.deepEqual(result, ['foo bar baz'])
 })
 
-test('celsius should convert the temperature to the Celsius scale', t => {
+test('celsius should convert the temperature to the Celsius scale, celsius is default scale', t => {
   const result = string.celsius('25')
   t.deepEqual(result, '25°C')
 })
 
-test('celsius should convert the temperature to the Celsius scale', t => {
+test('celsius should convert the celsius temperature to the Celsius scale', t => {
   const result = string.celsius('25°C')
   t.deepEqual(result, '25°C')
 })
 
-test('celsius should convert the temperature to the Celsius scale', t => {
-  const result = string.celsius('0°F')
+test('celsius should convert the fahrenheit temperature to the Celsius scale', t => {
+  var result = string.celsius('0°F')
   t.deepEqual(result, '-18°C')
-})
 
-test('celsius should convert the temperature to the Celsius scale', t => {
-  const result = string.celsius('70°F')
+  result = string.celsius('70°F')
   t.deepEqual(result, '21°C')
 })
 
-test('celsius should convert the temperature to the Celsius scale', t => {
-  const result = string.celsius('70°F')
-  t.deepEqual(result, '21°C')
-})
-
-test('celsius should convert the temperature to the Celsius scale', t => {
+test('celsius should convert the negative fahrenheit temperature to the Celsius scale', t => {
   const result = string.celsius('-10°F')
   t.deepEqual(result, '-23°C')
 })
 
-test('celsius should convert the temperature to the Celsius scale', t => {
-  const result = string.celsius('0K')
+test('celsius should convert the kelvin temperature to the Celsius scale', t => {
+  var result = string.celsius('0K')
   t.deepEqual(result, '-273°C')
-})
 
-test('celsius should convert the temperature to the Celsius scale', t => {
-  const result = string.celsius('300K')
+  result = string.celsius('300K')
   t.deepEqual(result, '27°C')
 })
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
+test('fahrenheit should convert the temperature to the Fahrenheit scale. fahrenheit is the default scale', t => {
   const result = string.fahrenheit('50')
   t.deepEqual(result, '50°F')
 })
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
+test('fahrenheit should convert the fahrenheit temperature to the Fahrenheit scale', t => {
   const result = string.fahrenheit('50°F')
   t.deepEqual(result, '50°F')
 })
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
-  const result = string.fahrenheit('30°C')
+test('fahrenheit should convert the celsius temperature to the Fahrenheit scale', t => {
+  var result = string.fahrenheit('30°C')
   t.deepEqual(result, '86°F')
-})
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
-  const result = string.fahrenheit('10°C')
+  result = string.fahrenheit('10°C')
   t.deepEqual(result, '50°F')
 })
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
+test('fahrenheit should convert the negative celsius temperature to the Fahrenheit scale', t => {
   const result = string.fahrenheit('-20.21°C')
   t.deepEqual(result, '-4°F')
 })
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
-  const result = string.fahrenheit('1K')
+test('fahrenheit should convert the kelvin temperature to the Fahrenheit scale', t => {
+  var result = string.fahrenheit('1K')
   t.deepEqual(result, '-458°F')
-})
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
-  const result = string.fahrenheit('300K')
+  result = string.fahrenheit('300K')
   t.deepEqual(result, '80°F')
-})
 
-test('fahrenheit should convert the temperature to the Fahrenheit scale', t => {
-  const result = string.fahrenheit('100K')
+  result = string.fahrenheit('100K')
   t.deepEqual(result, '-280°F')
 })
 
-test('kelvin should convert the temperature to the Kelvin scale', t => {
+test('kelvin should convert the temperature to the Kelvin scale. Kelvin is the default', t => {
   const result = string.kelvin('100')
   t.deepEqual(result, '100K')
 })
 
-test('kelvin should convert the temperature to the Kelvin scale', t => {
+test('kelvin should convert the kelvin temperature to the Kelvin scale', t => {
   const result = string.kelvin('100K')
   t.deepEqual(result, '100K')
 })
 
-test('kelvin should convert the temperature to the Kelvin scale', t => {
+test('kelvin should convert the celsius temperature to the Kelvin scale', t => {
   const result = string.kelvin('26°C')
   t.deepEqual(result, '299K')
 })
 
-test('kelvin should convert the temperature to the Kelvin scale', t => {
+test('kelvin should convert the negative celsius temperature to the Kelvin scale', t => {
   const result = string.kelvin('-10°C')
   t.deepEqual(result, '263K')
 })
 
-test('kelvin should convert the temperature to the Kelvin scale', t => {
+test('kelvin should convert the fahrenheit temperature to the Kelvin scale', t => {
   const result = string.kelvin('50°F')
   t.deepEqual(result, '283K')
 })
 
-test('kelvin should convert the temperature to the Kelvin scale', t => {
+test('kelvin should convert the negative fahrenheit temperature to the Kelvin scale', t => {
   const result = string.kelvin('-100°F')
   t.deepEqual(result, '200K')
 })


### PR DESCRIPTION
This should solve #74 
maybe i merged too much tests, anyway they are very similar.
if needed the can be split later.

except for a error relative to the absence of array.flat() (maybe my node version? i dunno) 
it run correctly test and lint

i'am not sure about the coverage


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#74: Update ava to the latest version](https://issuehunt.io/repos/58227632/issues/74)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->